### PR TITLE
fix for const errors in the generated roms

### DIFF
--- a/Core/Src/retro-go/rom_manager.c
+++ b/Core/Src/retro-go/rom_manager.c
@@ -8,9 +8,9 @@ unsigned ROM_DATA_LENGTH;
 #include "gb_roms.c"
 #include "nes_roms.c"
 
-const rom_system systems[] = {
-    nes_system,
-    gb_system
+const rom_system *systems[] = {
+    &nes_system,
+    &gb_system
 };
 
 const rom_manager rom_mgr = {
@@ -20,8 +20,8 @@ const rom_manager rom_mgr = {
 
 const rom_system *rom_manager_system(const rom_manager *mgr, char *name) {
     for(int i=0; i < mgr->systems_count; i++) {
-        if(strcmp(mgr->systems[i].system_name, name) == 0) {
-            return &mgr->systems[i];
+        if(strcmp(mgr->systems[i]->system_name, name) == 0) {
+            return mgr->systems[i];
         }
     }
     return NULL;

--- a/Core/Src/retro-go/rom_manager.h
+++ b/Core/Src/retro-go/rom_manager.h
@@ -17,7 +17,7 @@ typedef struct {
 } rom_system;
 
 typedef struct {
-    const rom_system *systems;
+    const rom_system **systems;
     uint32_t systems_count;
 } rom_manager;
 

--- a/parse_roms.py
+++ b/parse_roms.py
@@ -6,7 +6,7 @@ ROM_ENTRIES_TEMPLATE = """
 const rom_entry {name}[] = {{
     {body}
 }};
-const uint32_t {name}_count = {rom_count};
+#define {name}_count ({rom_count})
 """
 
 ROM_ENTRY_TEMPLATE = """\t{{.rom_name = "{name}", .flash_address = (uint32_t)&{variable_name}[0], .size={size}}},"""


### PR DESCRIPTION
Compiling with gcc 7.2.1 causes the following errors:

In file included from Core/Src/retro-go/rom_manager.c:8:0:
Core/Src/retro-go/gb_roms.c:65549:19: error: initializer element is not constant
.roms_count = gb_roms_count
^~~~~~~~~~~~~
Core/Src/retro-go/gb_roms.c:65549:19: note: (near initialization for 'gb_system.roms_count')
In file included from Core/Src/retro-go/rom_manager.c:9:0:
Core/Src/retro-go/nes_roms.c:6159:19: error: initializer element is not constant
.roms_count = nes_roms_count
^~~~~~~~~~~~~~
Core/Src/retro-go/nes_roms.c:6159:19: note: (near initialization for 'nes_system.roms_count')
Core/Src/retro-go/rom_manager.c:12:5: error: initializer element is not constant
nes_system,
^~~~~~~~~~
Core/Src/retro-go/rom_manager.c:12:5: note: (near initialization for 'systems[0]')
Core/Src/retro-go/rom_manager.c:13:5: error: initializer element is not constant
gb_system
^~~~~~~~~
Core/Src/retro-go/rom_manager.c:13:5: note: (near initialization for 'systems[1]')
make: *** [build_gb/rom_manager.o] Error 1

This commit fixes the compilation error. I could try the result, the screen keeps flashing with the menu. I don't know if this is caused by these changes or by the current state of the branch... (e.g. although I'm building 'gb', the menu shows 'nes').