### PR TITLE
make: use /bin/bash as shell

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -5,7 +5,8 @@
 DEBUG ?= 1
 # optimization
 OPT ?= -Og
-
+# use bash for shell commands
+SHELL = /bin/bash
 
 #######################################
 # paths


### PR DESCRIPTION
Generating the header file containing the git hash uses 'echo -ne'.
By default make will use /bin/sh to execute shell commands but on macOS
/bin/sh is limited and its built-in echo doesn't support the -n & -e
argument:
    /bin/sh -c 'echo -n -e "hello"'
    -n -e hello
The echo of bash does.