### PR TITLE
fix incremental building

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -233,7 +233,9 @@ Core/Inc/githash.h:
 	echo -ne '"\n#endif' >> $@
 .PHONY: Core/Inc/githash.h
 
-$(BUILD_DIR)/%.o: %.c Core/Inc/githash.h Makefile.common Makefile.$(TARGET) $(LDSCRIPT) $(SDK_HEADERS) | $(BUILD_DIR)
+Core/Src/main.c: Core/Inc/githash.h
+
+$(BUILD_DIR)/%.o: %.c Makefile.common Makefile.$(TARGET) $(LDSCRIPT) $(SDK_HEADERS) | $(BUILD_DIR)
 	$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.c=.lst)) $< -o $@
 
 $(BUILD_DIR)/%.o: %.s Makefile.common Makefile.$(TARGET) $(LDSCRIPT) | $(BUILD_DIR)


### PR DESCRIPTION
Every .c file had githash.h as a dependency and githash.h is
regenerated every time resulting in a complete build from scratch.
By having only main.c depending on githash.h, only that file gets
rebuild.