### PR TITLE
gb: use screen_blit_v3to5

### DIFF
--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -202,6 +202,71 @@ static void screen_blit_bilinear(void) {
     lcd_swap();
 }
 
+__attribute__((optimize("unroll-loops")))
+__attribute__((section (".itcram_hot_text")))
+static inline void screen_blit_v3to5(void) {
+    static uint32_t lastFPSTime = 0;
+    static uint32_t lastTime = 0;
+    static uint32_t frames = 0;
+    uint32_t currentTime = HAL_GetTick();
+    uint32_t delta = currentTime - lastFPSTime;
+
+    frames++;
+
+    if (delta >= 1000) {
+        int fps = (10000 * frames) / delta;
+        printf("FPS: %d.%d, frames %d, delta %d ms, skipped %d\n", fps / 10, fps % 10, delta, frames, skippedFrames);
+        frames = 0;
+        skippedFrames = 0;
+        lastFPSTime = currentTime;
+    }
+
+    lastTime = currentTime;
+
+    uint16_t *dest = lcd_get_active_buffer();
+
+    PROFILING_INIT(t_blit);
+    PROFILING_START(t_blit);
+
+#define CONV(_b0)    (((0b11111000000000000000000000&_b0)>>10) | ((0b000001111110000000000&_b0)>>5) | ((0b0000000000011111&_b0)))
+#define EXPAND(_b0)  (((0b1111100000000000 & _b0) << 10) | ((0b0000011111100000 & _b0) << 5) | ((0b0000000000011111 & _b0)))
+
+    int y_src = 0;
+    int y_dst = 0;
+    int w = currentUpdate->width;
+    int h = currentUpdate->height;
+    for (; y_src < h; y_src += 3, y_dst += 5) {
+        int x_src = 0;
+        int x_dst = 0;
+        for (; x_src < w; x_src += 1, x_dst += 2) {
+            uint16_t *src_col = &((uint16_t *)currentUpdate->buffer)[(y_src * w) + x_src];
+            uint32_t b0 = EXPAND(src_col[w * 0]);
+            uint32_t b1 = EXPAND(src_col[w * 1]);
+            uint32_t b2 = EXPAND(src_col[w * 2]);
+
+            dest[((y_dst + 0) * WIDTH) + x_dst] = CONV(b0);
+            dest[((y_dst + 1) * WIDTH) + x_dst] = CONV((b0+b1)>>1);
+            dest[((y_dst + 2) * WIDTH) + x_dst] = CONV(b1);
+            dest[((y_dst + 3) * WIDTH) + x_dst] = CONV((b1+b2)>>1);
+            dest[((y_dst + 4) * WIDTH) + x_dst] = CONV(b2);
+
+            dest[((y_dst + 0) * WIDTH) + x_dst + 1] = CONV(b0);
+            dest[((y_dst + 1) * WIDTH) + x_dst + 1] = CONV((b0+b1)>>1);
+            dest[((y_dst + 2) * WIDTH) + x_dst + 1] = CONV(b1);
+            dest[((y_dst + 3) * WIDTH) + x_dst + 1] = CONV((b1+b2)>>1);
+            dest[((y_dst + 4) * WIDTH) + x_dst + 1] = CONV(b2);
+        }
+    }
+
+    PROFILING_END(t_blit);
+
+#ifdef PROFILING_ENABLED
+    printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
+#endif
+
+    lcd_swap();
+}
+
 
 __attribute__((optimize("unroll-loops")))
 __attribute__((section (".itcram_hot_text")))
@@ -501,7 +566,8 @@ rg_app_desc_t * init(uint8_t load_state) {
     fb.byteorder = 1;
     // fb.blit_func = &screen_blit;
     // fb.blit_func = &screen_blit_bilinear;
-    fb.blit_func = &screen_blit_jth;
+    // fb.blit_func = &screen_blit_jth;
+    fb.blit_func = &screen_blit_v3to5;
 
     // Audio
     memset(audiobuffer_emulator, 0, sizeof(audiobuffer_emulator));


### PR DESCRIPTION
Use of the fancy blit to stretch 3 lines to 5 lines on the gameboy display.
(No doubt this can be made more efficient by making use of the palette).