### PR TITLE
Fix titles for games with periods "."

### DIFF
--- a/parse_roms.py
+++ b/parse_roms.py
@@ -28,7 +28,8 @@ const rom_system_t {name} = {{
 
 class ROM:
     def __init__(self, system_name: str, filepath: str):
-        self.name = os.path.basename(filepath).split(".")[0]
+        self.name = (os.path.splitext(os.path.basename(filepath))[0])
+        print(self.name)
         self.path = filepath
         self.size = os.path.getsize(filepath)
 


### PR DESCRIPTION
Titles such as `Ms. Pac-Man (USA)` no longer get cut off after the ".". Also added printout of parsed titles to ensure they look good before flashing to the system.