### PR TITLE
GBC cleanup fix

### DIFF
--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -14,7 +14,7 @@
 #include "gnuboy/sound.h"
 #include "gnuboy/regs.h"
 #include "gnuboy/rtc.h"
-#include "gnuboy/defs.h"
+#include "gnuboy/emu.h"
 #include "common.h"
 #include "rom_manager.h"
 


### PR DESCRIPTION
Required by [GBC optimizations from upstream](https://github.com/kbeckmann/retro-go-stm32/pull/4).