### PR TITLE
Load emulators from flash into memory

### DIFF
--- a/Core/Inc/gw_linker.h
+++ b/Core/Inc/gw_linker.h
@@ -22,3 +22,15 @@ extern uint32_t __ram_exec_end__;
 extern uint32_t _sitcram_hot;
 extern uint32_t __itcram_hot_start__;
 extern uint32_t __itcram_hot_end__;
+
+
+// If this is not an array the compiler might put in a memory_chk with dest_size 1...
+extern void * __RAM_EMU_START__[];
+extern void * _OVERLAY_NES_LOAD_START[];
+extern uint8_t _OVERLAY_NES_SIZE;
+extern void * _OVERLAY_NES_BSS_START[];
+extern uint8_t _OVERLAY_NES_BSS_SIZE;
+extern void * _OVERLAY_GB_LOAD_START[];
+extern uint8_t _OVERLAY_GB_SIZE;
+extern void * _OVERLAY_GB_BSS_START[];
+extern uint8_t _OVERLAY_GB_BSS_SIZE;

--- a/Core/Inc/porting.h
+++ b/Core/Inc/porting.h
@@ -14,16 +14,11 @@
 #include <math.h>
 #include <limits.h>
 
-#define IEXTFLASH_ATTR __attribute__((section (".extflash_text")))
-#define DEXTFLASH_ATTR __attribute__((section (".extflash_data")))
+#define IEXTFLASH_ATTR
+#define DEXTFLASH_ATTR
 
-#ifdef PORTING_USE_EXTFLASH
-#   define IRAM_ATTR __attribute__((section (".ram_text")))
-#   define DRAM_ATTR __attribute__((section (".ram_data")))
-#else
-#   define IRAM_ATTR
-#   define DRAM_ATTR
-#endif
+#define IRAM_ATTR
+#define DRAM_ATTR
 
 #ifndef DEBUG_RG_ALLOC
 

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -36,3 +36,21 @@ void HAL_SAI_TxCpltCallback(SAI_HandleTypeDef *hsai)
     dma_counter++;
     dma_state = DMA_TRANSFER_STATE_TC;
 }
+
+
+bool odroid_netplay_quick_start(void)
+{
+    return true;
+}
+
+// TODO: Move to own file
+void odroid_audio_mute(bool mute)
+{
+    if (mute) {
+        for (int i = 0; i < sizeof(audiobuffer_dma) / sizeof(audiobuffer_dma[0]); i++) {
+            audiobuffer_dma[i] = 0;
+        }
+    }
+
+    audio_mute = mute;
+}

--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -51,7 +51,7 @@ static bool saveSRAM = false;
 static int  saveSRAM_Timer = 0;
 
 // 3 pages
-uint8_t state_save_buffer[192 * 1024] __attribute__((section (".emulator_data")));
+uint8_t state_save_buffer[192 * 1024];
 
 
 // --- MAIN
@@ -484,23 +484,6 @@ void pcm_submit() {
             audiobuffer_dma[i + offset] = pcm.buf[i] >> shift;
         }
     }
-}
-
-bool odroid_netplay_quick_start(void)
-{
-    return true;
-}
-
-// TODO: Move to own file
-void odroid_audio_mute(bool mute)
-{
-    if (mute) {
-        for (int i = 0; i < sizeof(audiobuffer_dma) / sizeof(audiobuffer_dma[0]); i++) {
-            audiobuffer_dma[i] = 0;
-        }
-    }
-
-    audio_mute = mute;
 }
 
 

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -37,7 +37,7 @@ static bool autoload = false;
 
 
 // if i counted correctly this should max be 23077
-uint8_t nes_save_buffer[24000] __attribute__((section (".emulator_data")));
+uint8_t nes_save_buffer[24000];
 
 // TODO: Expose properly
 extern int nes_state_save(uint8_t *flash_ptr, size_t size);

--- a/Core/Src/retro-go/rg_emulators.c
+++ b/Core/Src/retro-go/rg_emulators.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "gw_linker.h"
 #include "rg_emulators.h"
 // #include "rg_favorites.h"
 #include "bitmaps.h"
@@ -373,8 +374,14 @@ void emulator_start(retro_emulator_file_t *file, bool load_state)
     retro_emulator_t *emu = file->emulator;
     // TODO: Make this cleaner
     if(strcmp(emu->system_name, "Nintendo Gameboy") == 0) {
+        memcpy(&__RAM_EMU_START__, &_OVERLAY_GB_LOAD_START, (size_t)&_OVERLAY_GB_SIZE);
+        memset(&_OVERLAY_GB_BSS_START, 0x0, (size_t)&_OVERLAY_GB_BSS_SIZE);
+        SCB_CleanDCache_by_Addr((uint32_t *)&__RAM_EMU_START__, (size_t)&_OVERLAY_GB_SIZE);
         app_main_gb(load_state);
     } else if(strcmp(emu->system_name, "Nintendo Entertainment System") == 0) {
+        memcpy(&__RAM_EMU_START__, &_OVERLAY_NES_LOAD_START, (size_t)&_OVERLAY_NES_SIZE);
+        memset(&_OVERLAY_NES_BSS_START, 0x0, (size_t)&_OVERLAY_NES_BSS_SIZE);
+        SCB_CleanDCache_by_Addr((uint32_t *)&__RAM_EMU_START__, (size_t)&_OVERLAY_NES_SIZE);
         app_main_nes(load_state);
     }
     

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ Core/Src/gw_buttons.c \
 Core/Src/gw_flash.c \
 Core/Src/gw_lcd.c \
 Core/Src/main.c \
-Core/Src/porting/gb/main_gb.c \
+Core/Src/porting/common.c \
 Core/Src/porting/odroid_audio.c \
 Core/Src/porting/odroid_display.c \
 Core/Src/porting/odroid_input.c \
@@ -28,9 +28,13 @@ Core/Src/porting/odroid_netplay.c \
 Core/Src/porting/odroid_overlay.c \
 Core/Src/porting/odroid_sdcard.c \
 Core/Src/porting/odroid_system.c \
+Core/Src/porting/crc32.c \
 Core/Src/stm32h7xx_hal_msp.c \
 Core/Src/stm32h7xx_it.c \
-Core/Src/system_stm32h7xx.c \
+Core/Src/system_stm32h7xx.c
+
+GNUBOY_C_SOURCES = \
+Core/Src/porting/gb/main_gb.c \
 retro-go-stm32/gnuboy-go/components/gnuboy/cpu.c \
 retro-go-stm32/gnuboy-go/components/gnuboy/debug.c \
 retro-go-stm32/gnuboy-go/components/gnuboy/emu.c \
@@ -40,8 +44,8 @@ retro-go-stm32/gnuboy-go/components/gnuboy/loader.c \
 retro-go-stm32/gnuboy-go/components/gnuboy/mem.c \
 retro-go-stm32/gnuboy-go/components/gnuboy/rtc.c \
 retro-go-stm32/gnuboy-go/components/gnuboy/sound.c \
-Core/Src/porting/crc32.c \
-Core/Src/porting/nes/common.c \
+
+NES_C_SOURCES = \
 Core/Src/porting/nes/main_nes.c \
 Core/Src/porting/nes/nofrendo_stm32.c \
 retro-go-stm32/nofrendo-go/components/nofrendo/cpu/dis6502.c \
@@ -120,6 +124,6 @@ include Makefile.common
 
 $(BUILD_DIR)/$(TARGET)_extflash.bin: $(BUILD_DIR)/$(TARGET).elf | $(BUILD_DIR)
 	$(V)$(ECHO) [ BIN ] $(notdir $@)
-	$(V)$(BIN) -j ._itcram_hot -j ._ram_exec -j ._extflash $< $(BUILD_DIR)/$(TARGET)_extflash.bin
+	$(V)$(BIN) -j ._itcram_hot -j ._ram_exec -j ._extflash -j .overlay_nes -j .overlay_gb $< $(BUILD_DIR)/$(TARGET)_extflash.bin
 
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -231,7 +231,7 @@ LIBDIR +=
 LDFLAGS += $(MCU) -specs=nano.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections
 
 # default action: build all
-all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET)_extflash.bin
+all: $(BUILD_DIR) $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET)_extflash.bin
 
 #$(REQUIRED_FILE):
 #	$(error $(REQUIRED_FILE_MSG))
@@ -240,8 +240,11 @@ all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET
 # build the application
 #######################################
 # list of objects
-OBJECTS = $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o) $(SDK_C_SOURCES:.c=.o)))
-vpath %.c $(sort $(dir $(C_SOURCES) $(SDK_C_SOURCES)))
+OBJECTS = $(addprefix $(BUILD_DIR)/core/,$(notdir $(C_SOURCES:.c=.o) $(SDK_C_SOURCES:.c=.o)))
+GNUBOY_OBJECTS = $(addprefix $(BUILD_DIR)/gnuboy/,$(notdir $(GNUBOY_C_SOURCES:.c=.o)))
+NES_OBJECTS = $(addprefix $(BUILD_DIR)/nes/,$(notdir $(NES_C_SOURCES:.c=.o)))
+
+vpath %.c $(sort $(dir $(C_SOURCES) $(NES_C_SOURCES) $(GNUBOY_C_SOURCES) $(SDK_C_SOURCES)))
 # list of ASM program objects
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(SDK_ASM_SOURCES:.s=.o)))
 vpath %.s $(sort $(dir $(SDK_ASM_SOURCES)))
@@ -292,19 +295,27 @@ CheckDirtySubmodules:
 endif
 .PHONY: CheckDirtySubmodules
 
-$(BUILD_DIR)/%.o: %.c Makefile.common Makefile $(LDSCRIPT) $(SDK_HEADERS) | $(BUILD_DIR) CheckDirtySubmodules
-	$(V)$(ECHO) [ CC ] $(notdir $<)
-	$(V)$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.c=.lst)) $< -o $@
-
-$(BUILD_DIR)/%.o: %.s Makefile.common Makefile $(LDSCRIPT) | $(BUILD_DIR) CheckDirtySubmodules
+$(BUILD_DIR)/%.o: %.s Makefile.common Makefile | $(BUILD_DIR) CheckDirtySubmodules
 	$(V)$(ECHO) [ AS ] $(notdir $<)
 	$(V)$(AS) -c $(CFLAGS) $< -o $@
 
-$(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile.common Makefile $(LDSCRIPT)
+$(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) $(NES_OBJECTS) $(GNUBOY_OBJECTS) Makefile.common Makefile $(LDSCRIPT)
 	$(V)$(ECHO) [ LD ] $(notdir $@)
-	$(V)$(CC) $(OBJECTS) $(LDFLAGS) -o $@
+	$(V)$(CC) $(OBJECTS) $(NES_OBJECTS) $(GNUBOY_OBJECTS) $(LDFLAGS) -o $@
 	$(V)$(SZ) $@
 	$(V)./size.sh $@
+
+$(BUILD_DIR)/core/%.o: %.c Makefile Makefile.common $(SDK_HEADERS) | $(BUILD_DIR) CheckDirtySubmodules
+	$(V)$(ECHO) [ CC core ] $(notdir $<)
+	$(V)$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/core/$(notdir $(<:.c=.lst)) $< -o $@
+
+$(BUILD_DIR)/nes/%.o: %.c Makefile Makefile.common $(SDK_HEADERS) | $(BUILD_DIR) CheckDirtySubmodules
+	$(V)$(ECHO) [ CC nes ] $(notdir $<)
+	$(V)$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/nes/$(notdir $(<:.c=.lst)) $< -o $@
+
+$(BUILD_DIR)/gnuboy/%.o: %.c Makefile Makefile.common $(SDK_HEADERS) | $(BUILD_DIR) CheckDirtySubmodules
+	$(V)$(ECHO) [ CC gb ] $(notdir $<)
+	$(V)$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/gnuboy/$(notdir $(<:.c=.lst)) $< -o $@
 
 $(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 	$(V)$(ECHO) [ HEX ] $(notdir $@)
@@ -312,6 +323,9 @@ $(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 
 $(BUILD_DIR):
 	$(V)mkdir $@
+	$(V)mkdir $@/core
+	$(V)mkdir $@/nes
+	$(V)mkdir $@/gnuboy
 
 
 #######################################

--- a/STM32H7B0VBTx_FLASH.ld
+++ b/STM32H7B0VBTx_FLASH.ld
@@ -67,12 +67,17 @@ __NULLPTR_LENGTH__  = 0x100;
 __ITCMRAM_LENGTH__  = 64K;
 __DTCMRAM_LENGTH__  = 128K;
 __RAM_UC_LENGTH__   = 300K;
-__RAM_LENGTH__      = 1024K - 300K;
+__RAM_CORE_LENGTH__ = 100K;
+__RAM_EMU_LENGTH__  = 1024K - __RAM_UC_LENGTH__ - __RAM_CORE_LENGTH__;
 __AHBRAM_LENGTH__   = 128K;
 __FLASH_LENGTH__    = 128K;
 
 __EXTFLASH_START__  = 0x90000000;
 
+__RAM_START__       = 0x24000000;
+__RAM_UC_START__    = __RAM_START__;
+__RAM_CORE_START__  = __RAM_START__ + __RAM_UC_LENGTH__;
+__RAM_EMU_START__    = __RAM_CORE_START__ + __RAM_CORE_LENGTH__;
 
 /* saveflash.ld sets __SAVEFLASH_LENGTH__ */
 INCLUDE build/saveflash.ld
@@ -86,10 +91,11 @@ MEMORY
 {
   /* RAM */
   NULLPTR  (xrw) : ORIGIN = 0x00000000, LENGTH =   __NULLPTR_LENGTH__
-  ITCMRAM  (xrw) : ORIGIN = 0x00000000 + __NULLPTR_LENGTH__, LENGTH =   64K - __NULLPTR_LENGTH__
+  ITCMRAM  (xrw) : ORIGIN = 0x00000000 + __NULLPTR_LENGTH__, LENGTH = __ITCMRAM_LENGTH__ - __NULLPTR_LENGTH__
   DTCMRAM  (xrw) : ORIGIN = 0x20000000, LENGTH =  __DTCMRAM_LENGTH__
-  RAM_UC   (xrw) : ORIGIN = 0x24000000, LENGTH = __RAM_UC_LENGTH__
-  RAM      (xrw) : ORIGIN = 0x24000000 + __RAM_UC_LENGTH__, LENGTH = __RAM_LENGTH__
+  RAM_UC   (xrw) : ORIGIN = __RAM_UC_START__, LENGTH = __RAM_UC_LENGTH__
+  RAM      (xrw) : ORIGIN = __RAM_CORE_START__, LENGTH = __RAM_CORE_LENGTH__
+  RAM_EMU  (xrw) : ORIGIN = __RAM_EMU_START__, LENGTH = __RAM_EMU_LENGTH__
   AHBRAM   (xrw) : ORIGIN = 0x30000000, LENGTH =  __AHBRAM_LENGTH__
 
   /* FLASH */
@@ -150,20 +156,6 @@ SECTIONS
     _sram_data = .;
     *(.ram_data)
     _eram_data = .;
-    . = ALIGN(4);
-    __extflash_odroid_start__ = .;
-    . = ALIGN(4);
-    build/nes*.o (.text .text* .rodata .rodata*)
-    . = ALIGN(4);
-    build/map*.o (.text .text* .rodata .rodata*)
-    . = ALIGN(4);
-    build/main_gb.o  (.text .text* .rodata .rodata*)
-    . = ALIGN(4);
-    build/dis6502.o (.text .text* .rodata .rodata*)
-    . = ALIGN(4);
-    build/cpu.o (.text .text* .rodata .rodata*)
-    . = ALIGN(4);
-    __extflash_odroid_end__ = .;
     __ram_exec_end__ = .;
   } >RAM AT> EXTFLASH
 
@@ -173,15 +165,15 @@ SECTIONS
     __extflash_nes_start__ = .;
     build/rom_*.o (.text .text* .rodata .rodata*)
     . = ALIGN(4);
-    build/miniz.o (.text .text* .rodata .rodata*)
+    build/core/miniz.o (.text .text* .rodata .rodata*)
     . = ALIGN(4);
-    build/lupng.o (.text .text* .rodata .rodata*)
+    build/core/lupng.o (.text .text* .rodata .rodata*)
     . = ALIGN(4);
-    build/gui.o (.text .text* .rodata .rodata*)
+    build/core/gui.o (.text .text* .rodata .rodata*)
     . = ALIGN(4);
-    build/sound.o  (.text .text* .rodata .rodata*)
+    build/core/logo*.o (.text .text* .rodata .rodata*)
     . = ALIGN(4);
-    build/logo*.o (.text .text* .rodata .rodata*)
+    build/core/header*.o (.text .text* .rodata .rodata*)
     . = ALIGN(4);
     __extflash_end_start__ = .;
     . = ALIGN(4);
@@ -200,6 +192,51 @@ SECTIONS
     __extflash_game_rom_end__ = .;
     __extflash_end__ = .;
   } > EXTFLASH
+
+  .overlay_nes __RAM_EMU_START__ : {
+      . = ALIGN(4);
+      build/nes/*.o (.data. data* .text .text* .rodata .rodata*)
+      . = ALIGN(4);
+      _OVERLAY_NES_LOAD_END = .;
+  } AT> EXTFLASH
+  _OVERLAY_NES_LOAD_START = LOADADDR(.overlay_nes);
+  _OVERLAY_NES_SIZE = SIZEOF(.overlay_nes);
+
+  .overlay_nes_bss _OVERLAY_NES_LOAD_END : {
+    . = ALIGN(4);
+    _OVERLAY_NES_BSS_START = .;
+    build/nes/*.o (.bss .bss*)
+    . = ALIGN(4);
+    build/nes/*.o (COMMON)
+    _OVERLAY_NES_BSS_END = .;
+  }
+  _OVERLAY_NES_BSS_SIZE = SIZEOF(.overlay_nes_bss);
+
+  .overlay_gb __RAM_EMU_START__ : {
+    . = ALIGN(4);
+    build/gnuboy/*.o (.data .data* .text .text* .rodata .rodata*)
+    . = ALIGN(4);
+    _OVERLAY_GB_LOAD_END = .;
+  } AT> EXTFLASH
+  _OVERLAY_GB_LOAD_START = LOADADDR(.overlay_gb);
+  _OVERLAY_GB_SIZE = SIZEOF(.overlay_gb);
+
+  .overlay_gb_bss _OVERLAY_GB_LOAD_END : {
+    . = ALIGN(4);
+    _OVERLAY_GB_BSS_START = .;
+    build/gnuboy/*.o (COMMON)
+    . = ALIGN(4);
+    build/gnuboy/*.o (.bss .bss*)
+    _OVERLAY_GB_BSS_END = .;
+  }
+  _OVERLAY_GB_BSS_SIZE = SIZEOF(.overlay_gb_bss);
+
+
+  ._ram_space_check_nes : {
+    . = . + SIZEOF(.overlay_nes);
+    . = . + SIZEOF(.overlay_nes_bss);
+  } >RAM_EMU
+
 
   ._saveflash :
   {
@@ -227,6 +264,7 @@ SECTIONS
     __ahbram_start__ = .;
     . = ALIGN(4);
     *(.audio)
+    *(.ahb)
     . = ALIGN(4);
     __ahbram_end__ = .;
   } > AHBRAM

--- a/size.sh
+++ b/size.sh
@@ -28,8 +28,6 @@ function get_section_length {
 function print_usage {
 	symbol=$1
 	length_symbol=$2
-    whitespace1=$3
-    whitespace2=$4
 	usage=$(get_section_length $symbol)
 	length=$(get_symbol $length_symbol)
 	free=$(( $length - $usage ))
@@ -46,7 +44,8 @@ dtc_usage=$(( dtc_size - dtc_free ))
 echo -e "dtcram\t$dtc_usage / $dtc_size ($dtc_free bytes free)"
 
 print_usage ram_uc   __RAM_UC_LENGTH__
-print_usage ram      __RAM_LENGTH__
+print_usage ram      __RAM_CORE_LENGTH__
+print_usage ram_emu  __RAM_EMU_LENGTH__
 print_usage ahbram   __AHBRAM_LENGTH__
 print_usage flash    __FLASH_LENGTH__
 print_usage extflash __EXTFLASH_LENGTH__


### PR DESCRIPTION
This was originally written by Thomas Roth <code@stacksmashing.net> to
make it possible to support more emulators than what fits into memory at
the same time (commit c13aa09b).

Instead of generating a monolithic binary, the different emulators are
stored in flash and loaded into ram right before they are launched.

This is the basis for adding more emulators e.g. smsplusgx.

Note: This commit also needs an updated retro-go-stm32 (See https://github.com/kbeckmann/retro-go-stm32/pull/5)