### PR TITLE
Make the list of roms have stable order so that we don't unnecessaril…

### DIFF
--- a/update_rom_files.sh
+++ b/update_rom_files.sh
@@ -13,7 +13,7 @@ if [[ ! -e $TMPFILE ]]; then
 	exit 1
 fi
 
-find ${@:2} -type f > "${TMPFILE}" 2> /dev/null
+find ${@:2} -type f | sort > "${TMPFILE}" 2> /dev/null
 
 if ! diff -q ${TMPFILE} ${filelist} > /dev/null 2> /dev/null; then
     echo "Updating file list ${filelist}"


### PR DESCRIPTION
…y recompile rom_manager.c etc.

I found that compiling on one system, then rsync to a pi for flashing, the pi wanted to recompile since the `build/rom_files.txt` order varied since `find` returned the filenames in a different order. Adding a `sort` makes the order the same between filesystems so the pi no longer attempts an unnecessary recompile.