### PR TITLE
osx: Fix for save state scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ linux/loaded_gb_rom.c
 linux/loaded_nes_rom.c
 
 save_states
+
+**/.DS_Store

--- a/dump_saves.sh
+++ b/dump_saves.sh
@@ -53,7 +53,7 @@ mkdir -p "$OUTDIR"
 
 for emu in gb nes gg sms; do
     mkdir -p "${OUTDIR}/${emu}"
-    COUNT=$(get_number_of_saves SAVE_${emu^^}_)
+    COUNT=$(get_number_of_saves SAVE_$(echo ${emu} | awk '{print toupper($0)}')_)
     for i in $(seq 0 $(( COUNT - 1 ))); do
         name=$(${GDB} "${ELF}" --batch -q -ex "printf \"%s\n\", ${emu}_roms[${i}].rom_name")
         address=$(${GDB} "${ELF}" --batch -q -ex "printf \"0x%08x\n\", ${emu}_roms[${i}].save_address")

--- a/program_saves.sh
+++ b/program_saves.sh
@@ -55,7 +55,7 @@ mkdir -p "$INDIR"
 
 for emu in gb nes gg sms; do
     mkdir -p "${INDIR}/${emu}"
-    COUNT=$(get_number_of_saves SAVE_${emu^^}_)
+    COUNT=$(get_number_of_saves SAVE_$(echo ${emu} | awk '{print toupper($0)}')_)
     for i in $(seq 0 $(( COUNT - 1 ))); do
         name=$(${GDB} "${ELF}" --batch -q -ex "printf \"%s\n\", ${emu}_roms[${i}].rom_name")
         # Note that 0x90000000 is subtracted from the address.


### PR DESCRIPTION
As OSX still ships with Bash 3.2.xx, this uses awk instead of double-carat (^^) for string capitalization.
I've also updated gitignore to include .DS_Store which are generated in the project folder by Finder.