### PR TITLE
parse_roms: generate a const struct of the roms

### DIFF
--- a/Core/Inc/retro-go/rg_emulators.h
+++ b/Core/Inc/retro-go/rg_emulators.h
@@ -10,19 +10,21 @@ typedef enum
     REGION_PAL
 } rom_region_t;
 
+typedef struct rom_system_t rom_system_t;
+
 typedef struct {
     const char *name;
     const char *ext;
     // char folder[32];
-    uint8_t *address;
+    const uint8_t *address;
     size_t size;
     const uint8_t *save_address;
     uint32_t save_size;
     size_t crc_offset;
     uint32_t checksum;
-    void *emulator;
     bool missing_cover;
     rom_region_t region;
+    const rom_system_t *system;
 } retro_emulator_file_t;
 
 typedef struct {
@@ -32,10 +34,11 @@ typedef struct {
     uint16_t crc_offset;
     uint16_t partition;
     struct {
-        retro_emulator_file_t *files;
+        const retro_emulator_file_t *files;
         int count;
     } roms;
     bool initialized;
+    const rom_system_t *system;
 } retro_emulator_t;
 
 void emulators_init();
@@ -46,3 +49,4 @@ void emulator_show_file_info(retro_emulator_file_t *file);
 void emulator_crc32_file(retro_emulator_file_t *file);
 bool emulator_build_file_object(const char *path, retro_emulator_file_t *out_file);
 const char *emu_get_file_path(retro_emulator_file_t *file);
+retro_emulator_t *file_to_emu(retro_emulator_file_t *file);

--- a/Core/Inc/retro-go/rom_manager.h
+++ b/Core/Inc/retro-go/rom_manager.h
@@ -4,29 +4,20 @@
 
 #include "rg_emulators.h"
 
-typedef struct {
-    const char *rom_name;
-    const uint8_t *flash_address;
-    uint32_t size;
-    const uint8_t *save_address;
-    uint32_t save_size;
-    rom_region_t region;
-} rom_entry_t;
-
-typedef struct {
+struct rom_system_t {
     char *system_name;
-    const rom_entry_t *roms;
+    const retro_emulator_file_t *roms;
     char *extension;
     uint32_t roms_count;
-} rom_system_t;
+};
 
 typedef struct {
-    const rom_system_t *systems;
+    const rom_system_t **systems;
     uint32_t systems_count;
 } rom_manager_t;
 
 extern const rom_manager_t rom_mgr;
-extern unsigned char *ROM_DATA;
+extern const unsigned char *ROM_DATA;
 extern unsigned ROM_DATA_LENGTH;
 extern retro_emulator_file_t *ACTIVE_FILE;
 

--- a/Core/Src/retro-go/gui.c
+++ b/Core/Src/retro-go/gui.c
@@ -320,7 +320,7 @@ void gui_draw_list(tab_t *tab)
 
 void gui_draw_cover(retro_emulator_file_t *file)
 {
-    retro_emulator_t *emu = (retro_emulator_t *)file->emulator;
+    retro_emulator_t *emu = file_to_emu(file);
 
     if (gp_buffer == NULL)
         gp_buffer = rg_alloc(gp_buffer_size, MEM_ANY);

--- a/Core/Src/retro-go/rom_manager.c
+++ b/Core/Src/retro-go/rom_manager.c
@@ -5,7 +5,7 @@
 #include "rg_emulators.h"
 #include "utils.h"
 
-unsigned char *ROM_DATA = NULL;
+const unsigned char *ROM_DATA = NULL;
 unsigned ROM_DATA_LENGTH;
 retro_emulator_file_t *ACTIVE_FILE = NULL;
 
@@ -14,11 +14,11 @@ retro_emulator_file_t *ACTIVE_FILE = NULL;
 #include "sms_roms.c"
 #include "gg_roms.c"
 
-const rom_system_t systems[] = {
-    nes_system,
-    gb_system,
-    sms_system,
-    gg_system,
+const rom_system_t *systems[] = {
+    &nes_system,
+    &gb_system,
+    &sms_system,
+    &gg_system,
 };
 
 const rom_manager_t rom_mgr = {
@@ -28,8 +28,8 @@ const rom_manager_t rom_mgr = {
 
 const rom_system_t *rom_manager_system(const rom_manager_t *mgr, char *name) {
     for(int i=0; i < mgr->systems_count; i++) {
-        if(strcmp(mgr->systems[i].system_name, name) == 0) {
-            return &mgr->systems[i];
+        if(strcmp(mgr->systems[i]->system_name, name) == 0) {
+            return mgr->systems[i];
         }
     }
     return NULL;


### PR DESCRIPTION
This avoids using malloc for the menu structure of the roms.

This should fix issue #64