### PR TITLE
fix dump & load save scripts

### DIFF
--- a/dump_saves.sh
+++ b/dump_saves.sh
@@ -55,7 +55,7 @@ for emu in gb nes gg sms; do
     mkdir -p "${OUTDIR}/${emu}"
     COUNT=$(get_number_of_saves SAVE_$(echo ${emu} | awk '{print toupper($0)}')_)
     for i in $(seq 0 $(( COUNT - 1 ))); do
-        name=$(${GDB} "${ELF}" --batch -q -ex "printf \"%s\n\", ${emu}_roms[${i}].rom_name")
+        name=$(${GDB} "${ELF}" --batch -q -ex "printf \"%s\n\", ${emu}_roms[${i}].name")
         address=$(${GDB} "${ELF}" --batch -q -ex "printf \"0x%08x\n\", ${emu}_roms[${i}].save_address")
         size=$(${GDB} "${ELF}" --batch -q -ex "printf \"0x%08x\n\", ${emu}_roms[${i}].save_size")
         echo ""

--- a/program_saves.sh
+++ b/program_saves.sh
@@ -57,7 +57,7 @@ for emu in gb nes gg sms; do
     mkdir -p "${INDIR}/${emu}"
     COUNT=$(get_number_of_saves SAVE_$(echo ${emu} | awk '{print toupper($0)}')_)
     for i in $(seq 0 $(( COUNT - 1 ))); do
-        name=$(${GDB} "${ELF}" --batch -q -ex "printf \"%s\n\", ${emu}_roms[${i}].rom_name")
+        name=$(${GDB} "${ELF}" --batch -q -ex "printf \"%s\n\", ${emu}_roms[${i}].name")
         # Note that 0x90000000 is subtracted from the address.
         address=$(${GDB} "${ELF}" --batch -q -ex "printf \"%ld\n\", ${emu}_roms[${i}].save_address - 0x90000000")
         size=$(${GDB} "${ELF}" --batch -q -ex "printf \"%d\n\", ${emu}_roms[${i}].save_size")


### PR DESCRIPTION
it appears member name changed from rom_name to just name at some recent point, save load & dump scripts on the current head of main fail without these changes.  I should note i'm on a raspberry pi while testing these scripts.