### PR TITLE
LZ4 compressed NES ROM support

### DIFF
--- a/Core/Inc/gw_linker.h
+++ b/Core/Inc/gw_linker.h
@@ -45,4 +45,5 @@ extern uint8_t _OVERLAY_PCE_SIZE;
 extern void * _OVERLAY_PCE_BSS_START[];
 extern uint8_t _OVERLAY_PCE_BSS_SIZE;
 
-
+extern uint8_t *_NES_ROM_UNPACK_BUFFER;
+extern uint8_t _NES_ROM_UNPACK_BUFFER_SIZE;

--- a/Core/Src/porting/lib/lz4_depack.c
+++ b/Core/Src/porting/lib/lz4_depack.c
@@ -1,6 +1,5 @@
 
 #include <stdlib.h>
-#include <string.h>
 
 #include "lz4_depack.h"
 

--- a/Core/Src/porting/lib/lz4_depack.c
+++ b/Core/Src/porting/lib/lz4_depack.c
@@ -1,0 +1,109 @@
+//#include <string.h>
+#include <stdlib.h>
+//#include <stdio.h>
+//#include <assert.h>
+
+#include "lz4_depack.h"
+
+/*********************************/
+/*
+ * blz4 - Example of LZ4 compression with BriefLZ algorithms
+ *
+ * C depacker
+ *
+ * Copyright (c) 2018 Joergen Ibsen
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must
+ *      not claim that you wrote the original software. If you use this
+ *      software in a product, an acknowledgment in the product
+ *      documentation would be appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must
+ *      not be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any source
+ *      distribution.
+ */
+
+unsigned long
+lz4_depack(const void *src, void *dst, unsigned long packed_size)
+{
+	const unsigned char *in = (unsigned char *) src;
+	unsigned char *out = (unsigned char *) dst;
+	unsigned long dst_size = 0;
+	unsigned long cur = 0;
+	unsigned long prev_match_start = 0;
+
+	if (in[0] == 0) {
+		return 0;
+	}
+
+	/* Main decompression loop */
+	while (cur < packed_size) {
+		unsigned long token = in[cur++];
+		unsigned long lit_len = token >> 4;
+		unsigned long len = (token & 0x0F) + 4;
+		unsigned long offs;
+		unsigned long i;
+
+		/* Read extra literal length bytes */
+		if (lit_len == 15) {
+			while (in[cur] == 255) {
+				lit_len += 255;
+				++cur;
+			}
+			lit_len += in[cur++];
+		}
+
+		/* Copy literals */
+		for (i = 0; i < lit_len; ++i) {
+			out[dst_size++] = in[cur++];
+		}
+
+		/* Check for last incomplete sequence */
+		if (cur == packed_size) {
+			/* Check parsing restrictions */
+			if (dst_size >= 5 && lit_len < 5) {
+				return 0;
+			}
+
+			if (dst_size > 12 && dst_size - prev_match_start < 12) {
+				return 0;
+			}
+
+			break;
+		}
+
+		/* Read offset */
+		offs = (unsigned long) in[cur] | ((unsigned long) in[cur + 1] << 8);
+		cur += 2;
+
+		/* Read extra length bytes */
+		if (len == 19) {
+			while (in[cur] == 255) {
+				len += 255;
+				++cur;
+			}
+			len += in[cur++];
+		}
+
+		prev_match_start = dst_size;
+
+		/* Copy match */
+		for (i = 0; i < len; ++i) {
+			out[dst_size] = out[dst_size - offs];
+			++dst_size;
+		}
+	}
+
+	/* Return decompressed size */
+	return dst_size;
+}

--- a/Core/Src/porting/lib/lz4_depack.c
+++ b/Core/Src/porting/lib/lz4_depack.c
@@ -1,9 +1,102 @@
-//#include <string.h>
+
 #include <stdlib.h>
-//#include <stdio.h>
-//#include <assert.h>
+#include <string.h>
 
 #include "lz4_depack.h"
+
+/*
+ LZ4 uncompress function
+*src 		: pointer on source buffer (LZ4 file format)
+*dst 		: pointer on destination buffer
+return the size of uncompressed data
+return 0 if there is an error
+ */
+unsigned int
+lz4_uncompress(const void *src, void *dst)
+{
+	const unsigned char *in = (unsigned char *)src;
+	unsigned char *out = (unsigned char *)dst;
+
+	unsigned int uncompressed_size = 0;
+	unsigned int compressed_size = 0;
+	unsigned int original_size = 0;
+	unsigned int content_offset = 0;
+	unsigned int compressed_size_offset = 0;
+	unsigned char flags;
+
+	/* check if it's LZ4  format */
+	if (memcmp(&in[0], LZ4_MAGIC, LZ4_MAGIC_SIZE) == 0)
+	{
+
+		/* Parse the header to determine :
+		- the compressed size
+		- the content offset 
+		- the original size (if present) */
+
+		/* get the header flags */
+		memcpy(&flags, &in[LZ4_FLG_OFFSET], sizeof(flags));
+
+		/* Content size field in header ? */
+		if ((flags & LZ4_FLG_MASK_C_SIZE) != 0)
+		{
+			memcpy(&original_size, &in[LZ4_CONTENT_SIZE_OFFSET], sizeof(original_size));
+			compressed_size_offset += LZ4_CONTENT_SIZE;
+		}
+
+		/* optional Dict. field in header ? */
+		if ((flags & LZ4_FLG_MASK_DICTID) != 0)
+		{
+			compressed_size_offset += LZ4_DICTID_SIZE;
+		}
+
+		/* Add the minimum header size  */
+		compressed_size_offset += LZ4_MAGIC_SIZE + LZ4_FLG_SIZE + LZ4_BD_SIZE + LZ4_HC_SIZE;
+		content_offset += compressed_size_offset + LZ4_FRAME_SIZE;
+
+		/* get the compressed size */
+		memcpy(&compressed_size, &in[compressed_size_offset], sizeof(compressed_size));
+
+		/* Uncompress the content to RAM */
+		uncompressed_size = lz4_depack(&in[content_offset], out, compressed_size);
+
+		/* Additional control */
+		if ((flags & LZ4_FLG_MASK_C_SIZE) != 0)
+		{
+			if (uncompressed_size != original_size)
+				uncompressed_size = 0;
+		}
+	}
+
+	return uncompressed_size;
+}
+
+/*
+LZ4  function to get the uncompressed size from LZ4 header
+*src 				: pointer on source buffer (LZ4 file format)
+return the the uncompressed size of the content
+return 0 if there is an error
+ */
+unsigned int
+lz4_get_original_size(const void *src)
+{
+
+	const unsigned char *in = (unsigned char *)src;
+	unsigned int original_size = 0;
+	unsigned char flags;
+
+	/* check if it's LZ4  format */
+	/* get the original size of the content to uncompress from the LZ4 header */
+	if (memcmp(&in[0], LZ4_MAGIC, LZ4_MAGIC_SIZE) == 0)
+	{
+
+		memcpy(&flags, &in[LZ4_FLG_OFFSET], sizeof(flags));
+
+		if ((flags & LZ4_FLG_MASK_C_SIZE) != 0)
+			memcpy(&original_size, &in[LZ4_CONTENT_SIZE_OFFSET], sizeof(original_size));
+	}
+
+	return original_size;
+}
 
 /*********************************/
 /*
@@ -36,18 +129,20 @@
 unsigned long
 lz4_depack(const void *src, void *dst, unsigned long packed_size)
 {
-	const unsigned char *in = (unsigned char *) src;
-	unsigned char *out = (unsigned char *) dst;
+	const unsigned char *in = (unsigned char *)src;
+	unsigned char *out = (unsigned char *)dst;
 	unsigned long dst_size = 0;
 	unsigned long cur = 0;
 	unsigned long prev_match_start = 0;
 
-	if (in[0] == 0) {
+	if (in[0] == 0)
+	{
 		return 0;
 	}
 
 	/* Main decompression loop */
-	while (cur < packed_size) {
+	while (cur < packed_size)
+	{
 		unsigned long token = in[cur++];
 		unsigned long lit_len = token >> 4;
 		unsigned long len = (token & 0x0F) + 4;
@@ -55,8 +150,10 @@ lz4_depack(const void *src, void *dst, unsigned long packed_size)
 		unsigned long i;
 
 		/* Read extra literal length bytes */
-		if (lit_len == 15) {
-			while (in[cur] == 255) {
+		if (lit_len == 15)
+		{
+			while (in[cur] == 255)
+			{
 				lit_len += 255;
 				++cur;
 			}
@@ -64,18 +161,22 @@ lz4_depack(const void *src, void *dst, unsigned long packed_size)
 		}
 
 		/* Copy literals */
-		for (i = 0; i < lit_len; ++i) {
+		for (i = 0; i < lit_len; ++i)
+		{
 			out[dst_size++] = in[cur++];
 		}
 
 		/* Check for last incomplete sequence */
-		if (cur == packed_size) {
+		if (cur == packed_size)
+		{
 			/* Check parsing restrictions */
-			if (dst_size >= 5 && lit_len < 5) {
+			if (dst_size >= 5 && lit_len < 5)
+			{
 				return 0;
 			}
 
-			if (dst_size > 12 && dst_size - prev_match_start < 12) {
+			if (dst_size > 12 && dst_size - prev_match_start < 12)
+			{
 				return 0;
 			}
 
@@ -83,12 +184,14 @@ lz4_depack(const void *src, void *dst, unsigned long packed_size)
 		}
 
 		/* Read offset */
-		offs = (unsigned long) in[cur] | ((unsigned long) in[cur + 1] << 8);
+		offs = (unsigned long)in[cur] | ((unsigned long)in[cur + 1] << 8);
 		cur += 2;
 
 		/* Read extra length bytes */
-		if (len == 19) {
-			while (in[cur] == 255) {
+		if (len == 19)
+		{
+			while (in[cur] == 255)
+			{
 				len += 255;
 				++cur;
 			}
@@ -98,7 +201,8 @@ lz4_depack(const void *src, void *dst, unsigned long packed_size)
 		prev_match_start = dst_size;
 
 		/* Copy match */
-		for (i = 0; i < len; ++i) {
+		for (i = 0; i < len; ++i)
+		{
 			out[dst_size] = out[dst_size - offs];
 			++dst_size;
 		}

--- a/Core/Src/porting/lib/lz4_depack.h
+++ b/Core/Src/porting/lib/lz4_depack.h
@@ -1,10 +1,75 @@
+
+
 #ifndef DEF_LZ4DEPACK
 #define DEF_LZ4DEPACK
 
-/* MAGIC WORD found as a magic word in LZ4 payload */
-#define  ROM_LZ4_MAGIC       "\x04\x22\x4D\x18" // LE 0x184D2204U
+// https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md
 
-/* LZ4 depack function */
+/* MAGIC WORD found as a magic word in LZ4 payload */
+#define LZ4_MAGIC "\x04\x22\x4D\x18" // LE 0x184D2204U
+
+/* LZ4 file format */
+
+/* LZ4 file structure
+MagicNb	F. Descriptor	Block	(...)	EndMark	C.Checksum
+4 bytes	3-15 bytes			            4 bytes	0-4 bytes
+
+LZ4 F.Descriptor format
+FLG	    BD	   (Content Size)	(Dictionary ID)	HC
+1 byte	1 byte	0 - 8 bytes	    0 - 4 bytes	    1 byte
+
+FLG byte
+BitNb	    7-6	    5	    4	        3	    2	        1	        0
+FieldName	Version	B.Indep	B.Checksum	C.Size	C.Checksum	Reserved	DictID
+
+*/
+
+/* header fields size  */
+#define LZ4_MAGIC_SIZE 4
+#define LZ4_FLG_SIZE 1
+#define LZ4_BD_SIZE 1
+#define LZ4_CONTENT_SIZE 8
+#define LZ4_DICTID_SIZE 4
+#define LZ4_HC_SIZE 1
+
+/* footer fields size */
+#define LZ4_ENDMARK_SIZE 4
+#define LZ4_CHECKSUM_SIZE 4
+
+/* frame size */
+#define LZ4_FRAME_SIZE 4
+
+/* FLG bit masks */
+#define LZ4_FLG_MASK_DICTID 0x1
+#define LZ4_FLG_MASK_C_CHECKSUM 0x4
+#define LZ4_FLG_MASK_C_SIZE 0x8
+#define LZ4_FLG_MASK_B_CHECKSUM 0x10
+
+/* FLG field offset */
+#define LZ4_FLG_OFFSET (LZ4_MAGIC_SIZE)
+
+/* Content size offset if FLG C.Size */
+#define LZ4_CONTENT_SIZE_OFFSET (LZ4_MAGIC_SIZE + LZ4_FLG_SIZE + LZ4_BD_SIZE)
+
+/* LZ4 uncompress function
+*src 		: pointer on source buffer (LZ4 file format)
+*dst 		: pointer on destination buffer
+src_size 	: size of source buffer
+ */
+unsigned int lz4_uncompress(const void *src, void *dst);
+
+/* LZ4  function to get the uncompressed size from LZ4 header
+*src 				: pointer on source buffer (LZ4 file format)
+packect_size 	: size of the compressed packet to unpack
+return true if success
+ */
+unsigned int lz4_get_original_size(const void *src);
+
+/* LZ4 depack function
+*src 				: pointer on source buffer (LZ4 file format)
+return the size of the original (uncompressed) content
+return 0 if it's not a LZ4 file format by checking LZ4_MAGIC NUMBER. 
+ */
 unsigned long lz4_depack(const void *src, void *dst, unsigned long packed_size);
 
-#endif /* _LZ4DEPACK */
+#endif /* DEF_LZ4DEPACK */

--- a/Core/Src/porting/lib/lz4_depack.h
+++ b/Core/Src/porting/lib/lz4_depack.h
@@ -1,0 +1,10 @@
+#ifndef DEF_LZ4DEPACK
+#define DEF_LZ4DEPACK
+
+/* MAGIC WORD found as a magic word in LZ4 payload */
+#define  ROM_LZ4_MAGIC       "\x04\x22\x4D\x18" // LE 0x184D2204U
+
+/* LZ4 depack function */
+unsigned long lz4_depack(const void *src, void *dst, unsigned long packed_size);
+
+#endif /* _LZ4DEPACK */

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -483,28 +483,39 @@ size_t osd_getromdata(unsigned char **data)
     /* src pointer to the ROM data in the external flash (raw or LZ4) */
     const unsigned char *src = ROM_DATA;
 
-    if (memcmp(&src[0], ROM_LZ4_MAGIC, 4) == 0) {
+    if (memcmp(&src[0], LZ4_MAGIC, LZ4_MAGIC_SIZE) == 0)
+    {
+
         /* dest pointer to the ROM data in the internal RAM (raw) */
-        unsigned char *dest = (unsigned char *) &_NES_ROM_UNPACK_BUFFER;
-        uint32_t lz4_compressed_size;
-        uint32_t lz4_uncompressed_size;
-        int32_t rom_size_src;
-        uint32_t available_size = (uint32_t) &_NES_ROM_UNPACK_BUFFER_SIZE;
+        unsigned char *dest = (unsigned char *)&_NES_ROM_UNPACK_BUFFER;
+        uint32_t lz4_original_size;
+        int32_t lz4_uncompressed_size;
+        uint32_t available_size = (uint32_t)&_NES_ROM_UNPACK_BUFFER_SIZE;
 
         printf("LZ4 compressed ROM detected.\n");
-        printf("Uncompressing to %p. %d bytes available.\n", dest, available_size);
+        printf("Uncompressing to %p. %ld bytes available.\n", dest, available_size);
 
-        memcpy(&lz4_uncompressed_size, &src[6], sizeof(lz4_uncompressed_size));
+        /* get the content size to uncompress */
+        lz4_original_size = lz4_get_original_size(src);
 
-        lz4_compressed_size = ROM_DATA_LENGTH - 19;
-        rom_size_src = lz4_depack(&src[19], dest, lz4_compressed_size);
-        assert (rom_size_src < lz4_uncompressed_size);
+        /* Check if there is enough memory to uncompress it */
+        assert(available_size >= lz4_original_size);
+
+        /* Uncompress the content to RAM */
+        lz4_uncompressed_size = lz4_uncompress(src, dest);
+
+        printf("Uncompressed size: %ld bytes.\n", lz4_uncompressed_size);
+
+        /* Check if the uncompressed content size is as expected */
+        assert(lz4_original_size == lz4_uncompressed_size);
 
         *data = dest;
 
-        return rom_size_src;
-    } else {
-        *data = (unsigned char *) ROM_DATA;
+        return lz4_uncompressed_size;
+    }
+    else
+    {
+        *data = (unsigned char *)ROM_DATA;
 
         return ROM_DATA_LENGTH;
     }

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ retro-go-stm32/gnuboy-go/components/gnuboy/sound.c \
 NES_C_SOURCES = \
 Core/Src/porting/nes/main_nes.c \
 Core/Src/porting/nes/nofrendo_stm32.c \
+Core/Src/porting/lib/lz4_depack.c \
 retro-go-stm32/nofrendo-go/components/nofrendo/cpu/dis6502.c \
 retro-go-stm32/nofrendo-go/components/nofrendo/cpu/nes6502.c \
 retro-go-stm32/nofrendo-go/components/nofrendo/mappers/map000.c \
@@ -130,6 +131,7 @@ Core/Src/porting/pce/main_pce.c
 
 C_INCLUDES +=  \
 -ICore/Inc \
+-ICore/Src/porting/lib \
 -Iretro-go-stm32/nofrendo-go/components/nofrendo/cpu \
 -Iretro-go-stm32/nofrendo-go/components/nofrendo/mappers \
 -Iretro-go-stm32/nofrendo-go/components/nofrendo/nes \

--- a/STM32H7B0VBTx_FLASH.ld
+++ b/STM32H7B0VBTx_FLASH.ld
@@ -210,10 +210,13 @@ SECTIONS
     build/nes/*.o (.bss .bss*)
     . = ALIGN(4);
     build/nes/*.o (COMMON)
+    . = ALIGN(4);
+    _NES_ROM_UNPACK_BUFFER = .;
     _OVERLAY_NES_BSS_END = .;
     __ram_emu_nes_end__ = .;
   }
   _OVERLAY_NES_BSS_SIZE = SIZEOF(.overlay_nes_bss);
+  _NES_ROM_UNPACK_BUFFER_SIZE = __RAM_EMU_START__ + __RAM_EMU_LENGTH__ - _NES_ROM_UNPACK_BUFFER;
 
   .overlay_gb __RAM_EMU_START__ : {
     . = ALIGN(4);

--- a/parse_roms.py
+++ b/parse_roms.py
@@ -154,7 +154,8 @@ class ROMParser():
         for e in extensions:
             roms_lz4 += self.find_roms(system_name, folder, e + ".lz4")
 
-        def contains_rom_by_name(rom: ROM, roms: list[ROM]):
+      #  def contains_rom_by_name(rom: ROM, roms: list[ROM]):
+        def contains_rom_by_name(rom, roms):        
             for r in roms:
                 if r.name == rom.name:
                     return True
@@ -163,6 +164,7 @@ class ROMParser():
         if compress:
             lz4_path = os.environ["LZ4_PATH"] if "LZ4_PATH" in os.environ else "lz4"
             for r in roms_raw:
+                print(r)
                 if not contains_rom_by_name(r, roms_lz4):
                     subprocess.run([lz4_path, "--best", "--content-size", "--no-frame-crc", r.path, r.path + ".lz4"])
             # Re-generate the lz4 rom list

--- a/parse_roms.py
+++ b/parse_roms.py
@@ -154,7 +154,6 @@ class ROMParser():
         for e in extensions:
             roms_lz4 += self.find_roms(system_name, folder, e + ".lz4")
 
-      #  def contains_rom_by_name(rom: ROM, roms: list[ROM]):
         def contains_rom_by_name(rom, roms):        
             for r in roms:
                 if r.name == rom.name:

--- a/parse_roms.py
+++ b/parse_roms.py
@@ -163,7 +163,6 @@ class ROMParser():
         if compress:
             lz4_path = os.environ["LZ4_PATH"] if "LZ4_PATH" in os.environ else "lz4"
             for r in roms_raw:
-                print(r)
                 if not contains_rom_by_name(r, roms_lz4):
                     subprocess.run([lz4_path, "--best", "--content-size", "--no-frame-crc", r.path, r.path + ".lz4"])
             # Re-generate the lz4 rom list


### PR DESCRIPTION
Hello,
This a simple POC to support LZ4 compressed NES ROM.
I observe 50% downsizing on at least 1 ROM.
Howto compress ROM:
you can use LZ4 compress tool with the following command line:
lz4 --best --content-size --no-rrame-crc rom.nes compressed_rom.nes

if it’s relevant, we can extend to other emulators and add a compression step in the python script.