### PR TITLE
Revert change to parse_roms.py: It breaks the build

### DIFF
--- a/parse_roms.py
+++ b/parse_roms.py
@@ -195,10 +195,6 @@ class ROMParser():
         f.write(SYSTEM_PROTO_TEMPLATE.format(
             name=variable_name))
 
-        if len(roms) == 0:
-            print("No roms found! Please add at least one rom to one of the the directories in roms/")
-            exit(-1)
-
         for i in range(len(roms)):
             rom = roms[i]
             if folder == "gb":


### PR DESCRIPTION
The recent change to parse_roms.py breaks the build, unless there is at least one ROM for every emulated system.

This reverts commit 203678a7e799d1d12fd78d53dcbb4905612e2bff.