### PR TITLE
Issue 101: Remember the last selected game in the menu after reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ linux/loaded_nes_rom.c
 
 save_states
 
+venv
+
 **/.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "retro-go-stm32"]
 	path = retro-go-stm32
-	url = git@github.com:rzinurov/retro-go-stm32.git
-# TODO: update url before merging
+	url = https://github.com/kbeckmann/retro-go-stm32

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "retro-go-stm32"]
 	path = retro-go-stm32
-	url = https://github.com/kbeckmann/retro-go-stm32
+	url = git@github.com:rzinurov/retro-go-stm32.git
+# TODO: update url before merging

--- a/Core/Src/porting/odroid_settings.c
+++ b/Core/Src/porting/odroid_settings.c
@@ -36,6 +36,8 @@ typedef struct persistent_config {
     void *startup_file;
 
     uint16_t main_menu_timeout_s;
+    uint16_t main_menu_selected_tab;
+    uint16_t main_menu_cursor;
 
     app_config_t app[ODROID_APPID_COUNT];
 
@@ -52,6 +54,8 @@ static const persistent_config_t persistent_config_default = {
     .font_size = 8,
     .startup_app = 0,
     .main_menu_timeout_s = 60 * 10, // Turn off after 10 minutes of idle time in the main menu
+    .main_menu_selected_tab = 0,
+    .main_menu_cursor = 0,
     .app = {
         {0}, // Launcher
         {
@@ -226,6 +230,24 @@ uint16_t odroid_settings_MainMenuTimeoutS_get()
 void odroid_settings_MainMenuTimeoutS_set(uint16_t value)
 {
     persistent_config_ram.main_menu_timeout_s = value;
+}
+
+uint16_t odroid_settings_MainMenuSelectedTab_get()
+{
+    return persistent_config_ram.main_menu_selected_tab;
+}
+void odroid_settings_MainMenuSelectedTab_set(uint16_t value)
+{
+    persistent_config_ram.main_menu_selected_tab = value;
+}
+
+uint16_t odroid_settings_MainMenuCursor_get()
+{
+    return persistent_config_ram.main_menu_cursor;
+}
+void odroid_settings_MainMenuCursor_set(uint16_t value)
+{
+    persistent_config_ram.main_menu_cursor = value;
 }
 
 

--- a/Core/Src/porting/odroid_system.c
+++ b/Core/Src/porting/odroid_system.c
@@ -118,10 +118,9 @@ runtime_stats_t odroid_system_get_stats()
 void odroid_system_sleep(void)
 {
     odroid_settings_StartupFile_set(ACTIVE_FILE);
-    odroid_settings_MainMenuSelectedTab_set(0);
-    odroid_settings_MainMenuCursor_set(0);
 
-    odroid_settings_commit();
+    // odroid_settings_commit();
+    gui_save_current_tab();
 
     GW_EnterDeepSleep();
 }

--- a/Core/Src/porting/odroid_system.c
+++ b/Core/Src/porting/odroid_system.c
@@ -118,6 +118,8 @@ runtime_stats_t odroid_system_get_stats()
 void odroid_system_sleep(void)
 {
     odroid_settings_StartupFile_set(ACTIVE_FILE);
+    odroid_settings_MainMenuSelectedTab_set(0);
+    odroid_settings_MainMenuCursor_set(0);
 
     odroid_settings_commit();
 

--- a/Core/Src/retro-go/gui.c
+++ b/Core/Src/retro-go/gui.c
@@ -90,7 +90,12 @@ void gui_init_tab(tab_t *tab)
     // tab->status[0] = 0;
 
     sprintf(str_buffer, "Sel.%.11s", tab->name);
-    tab->listbox.cursor = odroid_settings_int32_get(str_buffer, 0);
+    // tab->listbox.cursor = odroid_settings_int32_get(str_buffer, 0);
+    tab_t *selected_tab = gui_get_tab(odroid_settings_MainMenuSelectedTab_get());
+    if (tab->name == selected_tab->name)
+    {
+        tab->listbox.cursor = odroid_settings_MainMenuCursor_get();
+    }
 
     gui_event(TAB_INIT, tab);
 
@@ -106,9 +111,6 @@ tab_t *gui_get_tab(int index)
 tab_t *gui_get_current_tab()
 {
     return gui_get_tab(gui.selected);
-
-
-
 }
 
 tab_t *gui_set_current_tab(int index)
@@ -128,8 +130,10 @@ void gui_save_current_tab()
     tab_t *tab = gui_get_current_tab();
 
     sprintf(str_buffer, "Sel.%.11s", tab->name);
-    odroid_settings_int32_set(str_buffer, tab->listbox.cursor);
-    odroid_settings_int32_set("SelectedTab", gui.selected);
+    // odroid_settings_int32_set(str_buffer, tab->listbox.cursor);
+    odroid_settings_MainMenuCursor_set(tab->listbox.cursor);
+    // odroid_settings_int32_set("SelectedTab", gui.selected);
+    odroid_settings_MainMenuSelectedTab_set(gui.selected);
     odroid_settings_commit();
 }
 

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -174,7 +174,7 @@ void retro_loop()
         if (gui.joystick.values[i]) last_key = i;
     }
 
-    // gui.selected   = odroid_settings_int32_get(KEY_SELECTED_TAB, 0);
+    gui.selected      = odroid_settings_MainMenuSelectedTab_get();
     // gui.theme      = odroid_settings_int32_get(KEY_GUI_THEME, 0);
     // gui.show_empty = odroid_settings_int32_get(KEY_SHOW_EMPTY, 1);
     // gui.show_cover = odroid_settings_int32_get(KEY_SHOW_COVER, 1);


### PR DESCRIPTION
Add two extra variables to odroid settings:
 - main_menu_selected_tab
 - main_menu_cursor

Extra:
 - add `venv` directory to `.gitignore` (Python virtualenv)