### PR TITLE
replace zopfli with zlib until decompression bug is resolved

### DIFF
--- a/parse_roms.py
+++ b/parse_roms.py
@@ -192,9 +192,18 @@ def compress_zopfli(data, level=None):
         frame.append(data)
 
         return b"".join(frame)
-    import zopfli
 
-    c = zopfli.ZopfliCompressor(zopfli.ZOPFLI_FORMAT_DEFLATE)
+    # Actual zopfli compression is temporarily disabled until a GB/GBC bank
+    # swapping bug is resolved.
+    # Slightly less efficient vanilla deflate compression is applied
+
+    # import zopfli
+    # c = zopfli.ZopfliCompressor(zopfli.ZOPFLI_FORMAT_DEFLATE)
+
+    import zlib
+
+    c = zlib.compressobj(level=9, method=zlib.DEFLATED, wbits=-15, memLevel=9)
+
     compressed_data = c.compress(data) + c.flush()
     return compressed_data
 


### PR DESCRIPTION
There's currently a decompression bug (where at least in the beginning of Link's Awakening when link try's to get out of bed) where the wrong bank is swapped in and causes the game to crash. For some reason this doesn't happen when zlib is used as the compressor instead of zopfli