### PR TITLE
fix GB speedup, add 1.25x and 1.5x options

### DIFF
--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -512,10 +512,27 @@ static bool scaling_update_cb(odroid_dialog_choice_t *option, odroid_dialog_even
 bool speedup_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
     rg_app_desc_t *app = odroid_system_get_app();
-    if (event == ODROID_DIALOG_PREV && --app->speedupEnabled < 0) app->speedupEnabled = 2;
-    if (event == ODROID_DIALOG_NEXT && ++app->speedupEnabled > 2) app->speedupEnabled = 0;
+    if (event == ODROID_DIALOG_PREV && --app->speedupEnabled < SPEEDUP_1x) app->speedupEnabled = SPEEDUP_MAX - 1;
+    if (event == ODROID_DIALOG_NEXT && ++app->speedupEnabled >= SPEEDUP_MAX) app->speedupEnabled = SPEEDUP_1x;
 
-    sprintf(option->value, "%ldx", app->speedupEnabled + 1);
+    switch(app->speedupEnabled){
+        case SPEEDUP_1x:
+            strcpy(option->value, "1x");
+            break;
+        case SPEEDUP_1_25x:
+            strcpy(option->value, "1.25x");
+            break;
+        case SPEEDUP_1_5x:
+            strcpy(option->value, "1.5x");
+            break;
+        case SPEEDUP_2x:
+            strcpy(option->value, "2x");
+            break;
+        case SPEEDUP_3x:
+            strcpy(option->value, "3x");
+            break;
+    }
+
     return event == ODROID_DIALOG_ENTER;
 }
 

--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -512,10 +512,16 @@ static bool scaling_update_cb(odroid_dialog_choice_t *option, odroid_dialog_even
 bool speedup_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
     rg_app_desc_t *app = odroid_system_get_app();
-    if (event == ODROID_DIALOG_PREV && --app->speedupEnabled < SPEEDUP_1x) app->speedupEnabled = SPEEDUP_MAX - 1;
-    if (event == ODROID_DIALOG_NEXT && ++app->speedupEnabled >= SPEEDUP_MAX) app->speedupEnabled = SPEEDUP_1x;
+    if (event == ODROID_DIALOG_PREV && --app->speedupEnabled <= SPEEDUP_MIN) app->speedupEnabled = SPEEDUP_MAX - 1;
+    if (event == ODROID_DIALOG_NEXT && ++app->speedupEnabled >= SPEEDUP_MAX) app->speedupEnabled = SPEEDUP_MIN + 1;
 
     switch(app->speedupEnabled){
+        case SPEEDUP_0_5x:
+            strcpy(option->value, "0.5x");
+            break;
+        case SPEEDUP_0_75x:
+            strcpy(option->value, "0.75x");
+            break;
         case SPEEDUP_1x:
             strcpy(option->value, "1x");
             break;


### PR DESCRIPTION
This PR fixes the speedup option in the gameboy emulator and adds both 1.25x and 1.5x options.  #110 

Looking to see if you like this approach before I propagate it to the other emulators. They should all be done at once since they share the same speedup attribute.

In the `retro-go-stm32` submodule I add the following enum in `components/odroid/odroid_system.h`, pasted here to avoid all the submodule hassle:
```
enum
{
    SPEEDUP_1x,
    SPEEDUP_1_25x,
    SPEEDUP_1_5x,
    SPEEDUP_2x,
    SPEEDUP_3x,
    SPEEDUP_MAX,
};
typedef int32_t emu_speedup_t;
```