### PR TITLE
Save state and poweroff when power is pressed when in-menu

### DIFF
--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -340,6 +340,12 @@ int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, i
                 sel = -1;
                 break;
             }
+            else if (joystick.values[ODROID_INPUT_POWER]) {
+                sel = -1;
+                odroid_system_emu_save_state(0);
+                odroid_system_sleep();
+                break;
+            }
             if (options[sel].enabled) {
                 select = false;
                 if (joystick.values[ODROID_INPUT_LEFT]) {


### PR DESCRIPTION
Previously you couldn't turn off the system when in a menu via the power button.