### PR TITLE
Have NES use joystick abstraction

### DIFF
--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -36,10 +36,6 @@
 #endif
 
 
-static uint32_t pause_pressed;
-static uint32_t power_pressed;
-
-
 static odroid_video_frame_t update1 = {GB_WIDTH, GB_HEIGHT, GB_WIDTH * 2, 2, 0xFF, -1, NULL, NULL, 0, {}};
 static odroid_video_frame_t update2 = {GB_WIDTH, GB_HEIGHT, GB_WIDTH * 2, 2, 0xFF, -1, NULL, NULL, 0, {}};
 static odroid_video_frame_t *currentUpdate = &update1;
@@ -156,7 +152,6 @@ static void screen_blit_bilinear(void) {
 
     float x_scale = ((float) w2) / ((float) w1);
     float y_scale = ((float) h2) / ((float) h1);
-
 
 
 
@@ -552,6 +547,8 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused)
     uint8_t pause_after_frames;
     uint8_t frames_since_last_skip = 0;
     uint8_t pauseFrames = 0;
+    uint8_t pause_pressed = 0;
+    uint8_t power_pressed = 0;
 
     const int frameTime = get_frame_time(60);
 
@@ -681,7 +678,7 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused)
         if (pause_after_frames > 0) {
             pause_after_frames--;
             if (pause_after_frames == 0) {
-                pause_pressed = B_PAUSE;
+                pause_pressed = 1;
             }
         }
     }

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -32,9 +32,6 @@
 
 static uint8_t pause_after_frames;
 
-static uint32_t pause_pressed;
-static uint32_t power_pressed;
-
 static bool fullFrame = 0;
 static uint frameTime = 1000 / 60;
 static uint samplesPerFrame;
@@ -447,6 +444,8 @@ static bool palette_update_cb(odroid_dialog_choice_t *option, odroid_dialog_even
 
 void osd_getinput(void)
 {
+    static uint8_t pause_pressed;
+    static uint8_t power_pressed;
     uint16 pad0 = 0;
 
     wdog_refresh();
@@ -510,7 +509,7 @@ void osd_getinput(void)
     if (pause_after_frames > 0) {
         pause_after_frames--;
         if (pause_after_frames == 0) {
-            pause_pressed = B_PAUSE;
+            pause_pressed = 1;
         }
     }
 }

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -451,17 +451,19 @@ void osd_getinput(void)
 
     wdog_refresh();
 
-    uint32_t buttons = buttons_get();
-    if(buttons & B_GAME) pad0 |= INP_PAD_START;
-    if(buttons & B_TIME) pad0 |= INP_PAD_SELECT;
-    if(buttons & B_Up)   pad0 |= INP_PAD_UP;
-    if(buttons & B_Down)   pad0 |= INP_PAD_DOWN;
-    if(buttons & B_Left)   pad0 |= INP_PAD_LEFT;
-    if(buttons & B_Right)   pad0 |= INP_PAD_RIGHT;
-    if(buttons & B_A)   pad0 |= INP_PAD_A;
-    if(buttons & B_B)   pad0 |= INP_PAD_B;
+    odroid_gamepad_state_t joystick;
+    odroid_input_read_gamepad(&joystick);
 
-    if (pause_pressed != (buttons & B_PAUSE)) {
+    if (joystick.values[ODROID_INPUT_START])  pad0 |= INP_PAD_START;
+    if (joystick.values[ODROID_INPUT_SELECT]) pad0 |= INP_PAD_SELECT;
+    if (joystick.values[ODROID_INPUT_UP]) pad0 |= INP_PAD_UP;
+    if (joystick.values[ODROID_INPUT_DOWN]) pad0 |= INP_PAD_DOWN;
+    if (joystick.values[ODROID_INPUT_LEFT]) pad0 |= INP_PAD_LEFT;
+    if (joystick.values[ODROID_INPUT_RIGHT]) pad0 |= INP_PAD_RIGHT;
+    if (joystick.values[ODROID_INPUT_A]) pad0 |= INP_PAD_A;
+    if (joystick.values[ODROID_INPUT_B]) pad0 |= INP_PAD_B;
+
+    if (pause_pressed != joystick.values[ODROID_INPUT_VOLUME]) {
         if (pause_pressed) {
             printf("Pause pressed %ld=>%d\n", audio_mute, !audio_mute);
 
@@ -475,22 +477,23 @@ void osd_getinput(void)
             memset(framebuffer1, 0x0, sizeof(framebuffer1));
             memset(framebuffer2, 0x0, sizeof(framebuffer2));
         }
-        pause_pressed = buttons & B_PAUSE;
+        pause_pressed = joystick.values[ODROID_INPUT_VOLUME];
     }
 
-    if (power_pressed != (buttons & B_POWER)) {
+    if (power_pressed != joystick.values[ODROID_INPUT_POWER]) {
         printf("Power toggle %ld=>%d\n", power_pressed, !power_pressed);
-        power_pressed = buttons & B_POWER;
-        if (buttons & B_POWER) {
+        power_pressed = joystick.values[ODROID_INPUT_POWER];
+        if (power_pressed) {
             printf("Power PRESSED %ld\n", power_pressed);
             HAL_SAI_DMAStop(&hsai_BlockA1);
-            if(!(buttons & B_PAUSE)) {
+            if(!joystick.values[ODROID_INPUT_VOLUME]) {
                 SaveState("");
             }
 
             odroid_system_sleep();
         }
     }
+
 
     // Enable to log button presses
 #if 0

--- a/Core/Src/porting/pce/main_pce.c
+++ b/Core/Src/porting/pce/main_pce.c
@@ -431,7 +431,8 @@ void pce_pcm_submit() {
 
 int app_main_pce(uint8_t load_state, uint8_t start_paused) {
 
-    uint32_t pause_pressed = 0;
+    uint8_t pause_pressed = 0;
+    uint8_t power_pressed = 0;
     uint8_t pause_after_frames;
     uint8_t pauseFrames = 0;
     uint8_t frames_since_last_skip = 0;
@@ -475,7 +476,6 @@ int app_main_pce(uint8_t load_state, uint8_t start_paused) {
     if (load_state) LoadState(NULL);
 
     // Main emulator loop
-    uint32_t power_pressed = 0;
     printf("Main emulator loop start\n");
 
     while (true) {
@@ -577,7 +577,7 @@ int app_main_pce(uint8_t load_state, uint8_t start_paused) {
         if (pause_after_frames > 0) {
             pause_after_frames--;
             if (pause_after_frames == 0) {
-                pause_pressed = B_PAUSE;
+                pause_pressed = 1;
             }
         }
     }

--- a/Core/Src/porting/smsplusgx/main_smsplusgx.c
+++ b/Core/Src/porting/smsplusgx/main_smsplusgx.c
@@ -269,7 +269,7 @@ static void sms_draw_frame()
 
 static void sms_update_keys( odroid_gamepad_state_t* joystick )
 {
-  static uint32_t power_pressed = 0;
+  static uint8_t power_pressed = 0;
   uint8 k = 0;
 
   input.pad[0] = 0x00;
@@ -334,8 +334,8 @@ static void sms_update_keys( odroid_gamepad_state_t* joystick )
 int
 app_main_smsplusgx(uint8_t load_state, uint8_t start_paused, uint8_t is_coleco)
 {
-    uint32_t pause_pressed = 0;
-    uint32_t skipFrames = 0;
+    uint8_t pause_pressed = 0;
+    uint8_t skipFrames = 0;
     uint8_t pause_after_frames;
     uint8_t frames_since_last_skip = 0;
     uint8_t pauseFrames = 0;
@@ -482,7 +482,7 @@ app_main_smsplusgx(uint8_t load_state, uint8_t start_paused, uint8_t is_coleco)
         if (pause_after_frames > 0) {
             pause_after_frames--;
             if (pause_after_frames == 0) {
-                pause_pressed = B_PAUSE;
+                pause_pressed = 1;
             }
         }
     }


### PR DESCRIPTION
Just making it consistent with the other emus. Makes IO changes across emulators easier. I also changed the dtype and scope of `pause_pressed` and `power_pressed` to save a lil bit of stack, and to be more accurate for reading.