### PR TITLE
Long hold pause/set to toggle speedup

### DIFF
--- a/Core/Inc/porting/common.h
+++ b/Core/Inc/porting/common.h
@@ -37,6 +37,19 @@ extern const uint8_t volume_tbl[ODROID_AUDIO_VOLUME_MAX + 1];
 bool common_emu_frame_loop();
 void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choice_t *game_options);
 
+typedef struct {
+    uint last_busy;
+    uint busy_ms;
+    uint sleep_ms;
+} cpumon_stats_t;
+extern cpumon_stats_t cpumon_stats;
+
+/**
+ * Just calls `__WFI()` and measures time spent sleeping.
+ */
+void cpumon_sleep();
+void cpumon_reset();
+
 /**
  * Holds common higher-level emu options that need to be used at not-neat
  * locations in each emulator.

--- a/Core/Inc/porting/common.h
+++ b/Core/Inc/porting/common.h
@@ -33,3 +33,24 @@ extern int16_t audiobuffer_emulator[AUDIO_BUFFER_LENGTH] __attribute__((section 
 extern int16_t audiobuffer_dma[AUDIO_BUFFER_LENGTH * 2] __attribute__((section (".audio")));
 
 extern const uint8_t volume_tbl[ODROID_AUDIO_VOLUME_MAX + 1];
+
+bool common_emu_frame_loop();
+void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choice_t *game_options);
+
+/**
+ * Holds common higher-level emu options that need to be used at not-neat
+ * locations in each emulator.
+ *
+ * There should only be one of these objects instantiated.
+ */
+typedef struct {
+    uint32_t last_sync_time;
+    uint16_t skipped_frames;
+    int16_t frame_time_10us;
+    uint8_t skip_frames:1;
+    uint8_t pause_frames:1;
+    uint8_t pause_after_frames:3;
+    uint8_t startup_frames:2;
+} common_emu_state_t;
+
+extern common_emu_state_t common_emu_state;

--- a/Core/Inc/porting/common.h
+++ b/Core/Inc/porting/common.h
@@ -34,7 +34,7 @@ extern int16_t audiobuffer_dma[AUDIO_BUFFER_LENGTH * 2] __attribute__((section (
 
 extern const uint8_t volume_tbl[ODROID_AUDIO_VOLUME_MAX + 1];
 
-bool common_emu_frame_loop();
+bool common_emu_frame_loop(void);
 void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choice_t *game_options);
 
 typedef struct {
@@ -47,8 +47,8 @@ extern cpumon_stats_t cpumon_stats;
 /**
  * Just calls `__WFI()` and measures time spent sleeping.
  */
-void cpumon_sleep();
-void cpumon_reset();
+void cpumon_sleep(void);
+void cpumon_reset(void);
 
 /**
  * Holds common higher-level emu options that need to be used at not-neat

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -67,3 +67,131 @@ void odroid_audio_mute(bool mute)
 
     audio_mute = mute;
 }
+
+common_emu_state_t common_emu_state = {
+    .frame_time_10us = 10000 / 60,  // Most (all?) emus are 60fps
+};
+
+
+/**
+ * Call this each time a frame is drawn.
+ *
+ * Currently assumes that framerate is 60 fps.
+ *
+ * Emu responsibilities:
+ *    * increment `common_emu_state.skip_frames` if a frame came in too slow.
+ * @returns bool Whether or not to draw the frame.
+ */
+bool common_emu_frame_loop(){
+    rg_app_desc_t *app = odroid_system_get_app();
+    static int32_t leftovers = 0;
+    int16_t frame_time_10us = common_emu_state.frame_time_10us;
+    int16_t elapsed_10us = 100 * get_elapsed_time_since(common_emu_state.last_sync_time);
+    bool draw_frame = !common_emu_state.skip_frames;
+
+    common_emu_state.pause_frames = 0;
+    if(!draw_frame) common_emu_state.skip_frames = 0;
+
+    common_emu_state.last_sync_time = get_elapsed_time();
+
+    if(common_emu_state.startup_frames < 3) {
+        common_emu_state.startup_frames++;
+        return true;
+    }
+
+    switch(app->speedupEnabled){
+        case SPEEDUP_0_5x:
+            frame_time_10us *= 2;
+            break;
+        case SPEEDUP_0_75x:
+            frame_time_10us *= 5;
+            frame_time_10us /= 4;
+            break;
+        case SPEEDUP_1_25x:
+            frame_time_10us *= 4;
+            frame_time_10us /= 5;
+            break;
+        case SPEEDUP_1_5x:
+            frame_time_10us *= 2;
+            frame_time_10us /= 3;
+            break;
+        case SPEEDUP_2x:
+            frame_time_10us /= 2;
+            break;
+        case SPEEDUP_3x:
+            frame_time_10us /= 3;
+            break;
+    }
+    leftovers += (elapsed_10us - frame_time_10us);
+    if(leftovers > frame_time_10us) common_emu_state.skip_frames = 1;
+    else if(leftovers < -frame_time_10us) common_emu_state.pause_frames = 1;
+    common_emu_state.skipped_frames += common_emu_state.skip_frames;
+
+    return draw_frame;
+}
+
+
+/**
+ * Common input/macro/menuing features inside all emu loops. This is to be called
+ * after inputs are read into `joystick`, but before the actual emulation tick
+ * is called.
+ *
+ */
+void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choice_t *game_options) {
+    rg_app_desc_t *app = odroid_system_get_app();
+    static emu_speedup_t last_speedup = SPEEDUP_1_5x;
+    static uint8_t pause_pressed = 0;
+    static uint8_t power_pressed = 0;
+    static int8_t pause_pressed_count = 0;
+
+    if(pause_pressed && pause_pressed_count >= 0){
+        // Long-pressing PAUSE/SET to quickly toggle emulator speed.
+        if(pause_pressed_count < 127) {
+            pause_pressed_count++;
+        }
+        if(pause_pressed_count > 30) {  // 30 frames = half a second
+            if(app->speedupEnabled == SPEEDUP_1x) {
+                app->speedupEnabled = last_speedup;
+            }
+            else {
+                last_speedup = app->speedupEnabled;
+                app->speedupEnabled = SPEEDUP_1x;
+            }
+
+            pause_pressed_count = -1;
+        }
+    }
+
+    if (pause_pressed != joystick->values[ODROID_INPUT_VOLUME]) {
+        if (pause_pressed && pause_pressed_count >= 0) {
+            // PAUSE/SET has been released
+            odroid_overlay_game_menu(game_options);
+            memset(framebuffer1, 0x0, sizeof(framebuffer1));
+            memset(framebuffer2, 0x0, sizeof(framebuffer2));
+            common_emu_state.startup_frames = 0;
+            //common_emu_state.last_sync_time = get_elapsed_time();  // reset timer
+        }
+        pause_pressed = joystick->values[ODROID_INPUT_VOLUME];
+        pause_pressed_count = 0;
+    }
+
+    if (power_pressed != joystick->values[ODROID_INPUT_POWER]) {
+        printf("Power toggle %ld=>%d\n", power_pressed, !power_pressed);
+        power_pressed = joystick->values[ODROID_INPUT_POWER];
+        if (power_pressed) {
+            printf("Power PRESSED %ld\n", power_pressed);
+            HAL_SAI_DMAStop(&hsai_BlockA1);
+            if(!joystick->values[ODROID_INPUT_VOLUME]) {
+                app->saveState("");
+            }
+            odroid_system_sleep();
+        }
+    }
+
+    if (common_emu_state.pause_after_frames > 0) {
+        (common_emu_state.pause_after_frames)--;
+        if (common_emu_state.pause_after_frames == 0) {
+            pause_pressed = 1;
+        }
+    }
+}

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -202,12 +202,16 @@ void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choic
             else if(joystick->values[ODROID_INPUT_A]){
                 // Save State
                 last_key = ODROID_INPUT_A;
+                odroid_audio_mute(true);
                 odroid_system_emu_save_state(0);
+                odroid_audio_mute(false);
+                common_emu_state.startup_frames = 0;
             }
             else if(joystick->values[ODROID_INPUT_B]){
                 // Load State
                 last_key = ODROID_INPUT_B;
                 odroid_system_emu_load_state(0);
+                common_emu_state.startup_frames = 0;
             }
         }
 

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -71,7 +71,7 @@ void odroid_audio_mute(bool mute)
 }
 
 common_emu_state_t common_emu_state = {
-    .frame_time_10us = 10000 / 60,  // Most (all?) emus are 60fps
+    .frame_time_10us = 100000 / 60,  // Most (all?) emus are 60fps
 };
 
 

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -84,7 +84,7 @@ common_emu_state_t common_emu_state = {
  *    * increment `common_emu_state.skip_frames` if a frame came in too slow.
  * @returns bool Whether or not to draw the frame.
  */
-bool common_emu_frame_loop(){
+bool common_emu_frame_loop(void){
     rg_app_desc_t *app = odroid_system_get_app();
     static int32_t frame_integrator = 0;
     int16_t frame_time_10us = common_emu_state.frame_time_10us;
@@ -254,7 +254,7 @@ void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choic
     }
 }
 
-void cpumon_sleep(){
+void cpumon_sleep(void){
     uint t0 = get_elapsed_time();
     if(cpumon_stats.last_busy){
         cpumon_stats.busy_ms += t0 - cpumon_stats.last_busy;
@@ -268,7 +268,7 @@ void cpumon_sleep(){
     cpumon_stats.sleep_ms += t1 - t0;
 }
 
-void cpumon_reset(){
+void cpumon_reset(void){
     cpumon_stats.busy_ms = 0;
     cpumon_stats.sleep_ms = 0;
 }

--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -66,7 +66,7 @@ static inline void screen_blit(void) {
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
         frames = 0;
         common_emu_state.skipped_frames = 0;
         lastFPSTime = currentTime;
@@ -117,7 +117,7 @@ static void screen_blit_bilinear(void) {
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
         frames = 0;
         common_emu_state.skipped_frames = 0;
         lastFPSTime = currentTime;
@@ -178,7 +178,7 @@ static inline void screen_blit_v3to5(void) {
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
         frames = 0;
         common_emu_state.skipped_frames = 0;
         lastFPSTime = currentTime;
@@ -241,7 +241,7 @@ static inline void screen_blit_jth(void) {
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, delta, frames, common_emu_state.skipped_frames);
         frames = 0;
         common_emu_state.skipped_frames = 0;
         lastFPSTime = currentTime;
@@ -538,7 +538,7 @@ rg_app_desc_t * init(uint8_t load_state)
 
 void app_main_gb(uint8_t load_state, uint8_t start_paused)
 {
-    rg_app_desc_t *app = init(load_state);
+    init(load_state);
     odroid_gamepad_state_t joystick;
 
     if (start_paused) {
@@ -553,8 +553,6 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused)
         wdog_refresh();
 
         odroid_input_read_gamepad(&joystick);
-
-        uint startTime = get_elapsed_time();
 
         pad_set(PAD_UP, joystick.values[ODROID_INPUT_UP]);
         pad_set(PAD_RIGHT, joystick.values[ODROID_INPUT_RIGHT]);

--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -554,6 +554,14 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused)
 
         odroid_input_read_gamepad(&joystick);
 
+        bool drawFrame = common_emu_frame_loop();
+        odroid_dialog_choice_t options[] = {
+            {300, "Palette", "7/7", !hw.cgb, &palette_update_cb},
+            // {301, "More...", "", 1, &advanced_settings_cb},
+            ODROID_DIALOG_CHOICE_LAST
+        };
+        common_emu_input_loop(&joystick, options);
+
         pad_set(PAD_UP, joystick.values[ODROID_INPUT_UP]);
         pad_set(PAD_RIGHT, joystick.values[ODROID_INPUT_RIGHT]);
         pad_set(PAD_DOWN, joystick.values[ODROID_INPUT_DOWN]);
@@ -562,14 +570,6 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused)
         pad_set(PAD_START, joystick.values[ODROID_INPUT_START]);
         pad_set(PAD_A, joystick.values[ODROID_INPUT_A]);
         pad_set(PAD_B, joystick.values[ODROID_INPUT_B]);
-
-        bool drawFrame = common_emu_frame_loop();
-        odroid_dialog_choice_t options[] = {
-            {300, "Palette", "7/7", !hw.cgb, &palette_update_cb},
-            // {301, "More...", "", 1, &advanced_settings_cb},
-            ODROID_DIALOG_CHOICE_LAST
-        };
-        common_emu_input_loop(&joystick, options);
 
         emu_run(drawFrame);
 

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -30,7 +30,6 @@
 #define blit blit_5to6
 #endif
 
-static uint frameTime = 1000 / 60;
 static uint samplesPerFrame;
 static uint32_t vsync_wait_ms = 0;
 
@@ -351,7 +350,7 @@ void osd_blitscreen(bitmap_t *bmp)
 
     if (delta >= 1000) {
         int fps = (10000 * frames) / delta;
-        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %ld\n", fps / 10, fps % 10, frames, delta, common_emu_state.skipped_frames);
+        printf("FPS: %d.%d, frames %ld, delta %ld ms, skipped %d\n", fps / 10, fps % 10, frames, delta, common_emu_state.skipped_frames);
         frames = 0;
         common_emu_state.skipped_frames = 0;
         vsync_wait_ms = 0;
@@ -414,7 +413,7 @@ void osd_getinput(void)
     if (joystick.values[ODROID_INPUT_A]) pad0 |= INP_PAD_A;
     if (joystick.values[ODROID_INPUT_B]) pad0 |= INP_PAD_B;
 
-    const odroid_dialog_choice_t options[] = {
+    odroid_dialog_choice_t options[] = {
             {100, "Palette", "Default", 1, &palette_update_cb},
             // {101, "More...", "", 1, &advanced_settings_cb},
             ODROID_DIALOG_CHOICE_LAST

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -30,7 +30,6 @@
 #define blit blit_5to6
 #endif
 
-static bool fullFrame = 0;
 static uint frameTime = 1000 / 60;
 static uint samplesPerFrame;
 static uint32_t vsync_wait_ms = 0;
@@ -132,10 +131,7 @@ void osd_vsync()
 
     nes_audio_submit(nes_getptr()->apu->buffer, nes_getptr()->apu->samples_per_frame);
 
-    // Tick before submitting audio/syncing
-    odroid_system_tick(!nes_getptr()->drawframe, fullFrame, 0);
-
-    nes_getptr()->drawframe = (common_emu_state.skip_frames == 0);
+    nes_getptr()->drawframe = draw_frame;
 
     // Wait until the audio buffer has been transmitted
     static uint32_t last_dma_counter = 0;
@@ -143,7 +139,7 @@ void osd_vsync()
     if(draw_frame){
         for(uint8_t p = 0; p < common_emu_state.pause_frames + 1; p++) {
             while (dma_counter == last_dma_counter) {
-                __WFI();
+                cpumon_sleep();
             }
             last_dma_counter = dma_counter;
         }

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -404,6 +404,14 @@ void osd_getinput(void)
     odroid_gamepad_state_t joystick;
     odroid_input_read_gamepad(&joystick);
 
+    odroid_dialog_choice_t options[] = {
+            {100, "Palette", "Default", 1, &palette_update_cb},
+            // {101, "More...", "", 1, &advanced_settings_cb},
+            ODROID_DIALOG_CHOICE_LAST
+    };
+    common_emu_input_loop(&joystick, options);
+
+
     if (joystick.values[ODROID_INPUT_START])  pad0 |= INP_PAD_START;
     if (joystick.values[ODROID_INPUT_SELECT]) pad0 |= INP_PAD_SELECT;
     if (joystick.values[ODROID_INPUT_UP]) pad0 |= INP_PAD_UP;
@@ -412,13 +420,6 @@ void osd_getinput(void)
     if (joystick.values[ODROID_INPUT_RIGHT]) pad0 |= INP_PAD_RIGHT;
     if (joystick.values[ODROID_INPUT_A]) pad0 |= INP_PAD_A;
     if (joystick.values[ODROID_INPUT_B]) pad0 |= INP_PAD_B;
-
-    odroid_dialog_choice_t options[] = {
-            {100, "Palette", "Default", 1, &palette_update_cb},
-            // {101, "More...", "", 1, &advanced_settings_cb},
-            ODROID_DIALOG_CHOICE_LAST
-    };
-    common_emu_input_loop(&joystick, options);
 
     // Enable to log button presses
 #if 0

--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ Supported emulators:
 - Sega Master System (sms)
 - Sega SG-1000 (sg)
 
+## Controls
+
+Buttons are mapped as you would expect for each emulator. `GAME` is mapped to `START`,
+and `TIME` is mapped to `SELECT`. `PAUSE/SET` brings up the emulator menu.
+
+By default, pressing the power-button while in a game will automatically trigger
+a save-state prior to putting the system to sleep. Note that this WILL overwrite
+the previous save-state for the current game.
+
+### Macros
+
+Holding the `PAUSE/SET` button while pressing other buttons have the following actions:
+
+- `PAUSE/SET` + `TIME` = Toggle speedup between 1x and the last non-1x speed. Defaults to 1.5x.
+- `PAUSE/SET` + `UP` = Brightness up.
+- `PAUSE/SET` + `DOWN` = Brightness down.
+- `PAUSE/SET` + `RIGHT` = Volume up.
+- `PAUSE/SET` + `LEFT` = Volume down.
+- `PAUSE/SET` + `B` = Load state.
+- `PAUSE/SET` + `A` = Save state.
+- `PAUSE/SET` + `POWER` = Poweroff WITHOUT save-stating.
+
 ## How to report issues
 
 :exclamation: Please read this before reporting issues.


### PR DESCRIPTION
This is a PoC for long-holding (0.5 seconds) the pause/set button to toggle speedup between 1x and the last non-1x selected speed. If you're fine with this approach, i'll apply the same logic to the other emulators.

Based on https://github.com/kbeckmann/game-and-watch-retro-go/pull/113 since I'm assuming you'll be fine with that PR and didn't want to deal with merge conflicts afterwards.