### PR TITLE
Fix sms from emulating 5% too fast introduced in b6bbe8e2. 

### DIFF
--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -71,7 +71,7 @@ void odroid_audio_mute(bool mute)
 }
 
 common_emu_state_t common_emu_state = {
-    .frame_time_10us = 100000 / 60,  // Most (all?) emus are 60fps
+    .frame_time_10us = (uint16_t)(100000 / 60 + 0.5f),  // Reasonable default of 60FPS if not explicitly configured.
 };
 
 

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -525,12 +525,12 @@ int app_main_nes(uint8_t load_state, uint8_t start_paused)
 
     if (ACTIVE_FILE->region == REGION_PAL) {
         nes_region = NES_PAL;
-        common_emu_state.frame_time_10us = 100000 / 50;
+        common_emu_state.frame_time_10us = (uint16_t)(100000 / 50 + 0.5f);
         samplesPerFrame = (AUDIO_SAMPLE_RATE) / 50;
         HAL_SAI_Transmit_DMA(&hsai_BlockA1, (uint8_t *) audiobuffer_dma,  (2 * AUDIO_SAMPLE_RATE) / 50);
     } else {
         nes_region = NES_NTSC;
-        common_emu_state.frame_time_10us = 100000 / 60;
+        common_emu_state.frame_time_10us = (uint16_t)(100000 / 60 + 0.5f);
         //printf("frame_time_10us: %d\n", common_emu_state.frame_time_10us);
         samplesPerFrame = (AUDIO_SAMPLE_RATE) / 60;
         HAL_SAI_Transmit_DMA(&hsai_BlockA1, (uint8_t *) audiobuffer_dma, (2 * AUDIO_SAMPLE_RATE) / 60);

--- a/Core/Src/porting/smsplusgx/main_smsplusgx.c
+++ b/Core/Src/porting/smsplusgx/main_smsplusgx.c
@@ -364,8 +364,12 @@ app_main_smsplusgx(uint8_t load_state, uint8_t start_paused, uint8_t is_coleco)
     consoleIsCOL = sms.console == CONSOLE_COLECO;
     consoleIsSG  = sms.console == CONSOLE_SG1000;
 
-    const int refresh_rate = (sms.display == DISPLAY_NTSC) ? FPS_NTSC : FPS_PAL;
-    common_emu_state.frame_time_10us = 100 * get_frame_time(refresh_rate);
+    if (sms.display == DISPLAY_NTSC) {
+        common_emu_state.frame_time_10us = (uint16_t)(100000 / FPS_NTSC + 0.5f);
+    }
+    else {
+        common_emu_state.frame_time_10us = (uint16_t)(100000 / FPS_PAL + 0.5f);
+    }
 
     // Video
     memset(framebuffer1, 0, sizeof(framebuffer1));


### PR DESCRIPTION
Slightly increase target frame period accuracy for all emulators.