### PR TITLE
Working Bank2 Flashapp

### DIFF
--- a/Core/Inc/gw_linker.h
+++ b/Core/Inc/gw_linker.h
@@ -5,6 +5,7 @@
 extern uint8_t __SAVEFLASH_START__;
 extern uint8_t __SAVEFLASH_END__;
 extern uint8_t __EXTFLASH_START__;
+extern uint32_t __INTFLASH__;  // From linker, usually value 0x08000000 for bank 1, or 0x08100000 for bank 2
 
 extern uint8_t __NULLPTR_LENGTH__;
 

--- a/Core/Src/porting/odroid_system.c
+++ b/Core/Src/porting/odroid_system.c
@@ -82,12 +82,30 @@ IRAM_ATTR void odroid_system_tick(uint skippedFrame, uint fullFrame, uint busyTi
     statistics.lastTickTime = get_elapsed_time();
 }
 
+extern uint32_t __INTFLASH__;  // From linker, usually value 0x08000000 for bank 1, or 0x08100000 for bank 2
 void odroid_system_switch_app(int app)
 {
     printf("%s: Switching to app %d.\n", __FUNCTION__, app);
 
     switch (app) {
     case 0:
+        /**
+         * Setting these two places in memory tell tim's patched firmware
+         * bootloader running in bank 1 (0x08000000) to boot into retro-go
+         * immediately instead of the patched-stock-firmware..
+         *
+         * These are the last 8 bytes of the 128KB of TCM RAM.
+         *
+         * This uses a technique described here:
+         *      https://stackoverflow.com/a/56439572
+         *
+         *
+         * For stuff not running a bootloader like this, these commands are
+         * harmless.
+         */
+        *((uint32_t *)0x2001FFF8) = 0x544F4F42; // "BOOT"
+        *((uint32_t *)0x2001FFFC) = &__INTFLASH__; // vector table
+
         odroid_settings_StartupFile_set(0);
         odroid_settings_commit();
         NVIC_SystemReset();

--- a/Makefile.common
+++ b/Makefile.common
@@ -461,6 +461,18 @@ erase_intflash_2:
 	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "init; halt; flash erase_address 0x08100000 131072; resume; exit"
 .PHONY: erase_intflash2
 
+start_bank_1:
+	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg \
+		-c 'init; reset halt' \
+		-c 'set MSP 0x[string range [mdw 0x08000000] 12 19]' \
+		-c 'set PC 0x[string range [mdw 0x08000004] 12 19]' \
+		-c 'echo "Setting MSP -> $$MSP"' \
+		-c 'echo "Setting PC -> $$PC"' \
+		-c 'reg msp $$MSP' \
+		-c 'reg pc $$PC' \
+		-c 'resume;exit'
+.PHONY: start_bank_1
+
 start_bank_2:
 	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg \
 		-c 'init; reset halt' \

--- a/Makefile.common
+++ b/Makefile.common
@@ -280,9 +280,13 @@ CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 LDFLAGS += -Wl,--defsym=__EXTFLASH_OFFSET__=$(EXTFLASH_OFFSET)
 LDFLAGS += -Wl,--defsym=__EXTFLASH_TOTAL_LENGTH__=$(EXTFLASH_SIZE)
 
-ifeq ($(INTFLASH_BANK), 2)
-LDFLAGS += -Wl,--defsym=__INTFLASH__=0x08100000
+ifeq ($(INTFLASH_BANK), 1)
+	INTFLASH_ADDRESS = 0x08000000
+else ifeq ($(INTFLASH_BANK), 2)
+	INTFLASH_ADDRESS = 0x08100000
 endif
+
+LDFLAGS += -Wl,--defsym=__INTFLASH__=$(INTFLASH_ADDRESS)
 
 #######################################
 # LDFLAGS
@@ -447,12 +451,12 @@ openocd:
 
 # Programs the internal flash using a new OpenOCD instance
 flash_intflash: $(BUILD_DIR)/$(TARGET)_intflash.bin
-	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "program $< 0x08000000 verify reset exit"
+	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "program $< $(INTFLASH_ADDRESS) verify reset exit"
 .PHONY: flash_intflash
 
 # Flashes using an existing openocd instance
 flash_intflash_nc: $(BUILD_DIR)/$(TARGET)_intflash.bin
-	echo "program $< 0x08000000 verify reset" | nc -c localhost 4444
+	echo "program $< $(INTFLASH_ADDRESS) verify reset" | nc -c localhost 4444
 .PHONY: flashx
 
 flash_extflash: $(BUILD_DIR)/$(TARGET)_extflash.bin

--- a/Makefile.common
+++ b/Makefile.common
@@ -449,6 +449,30 @@ openocd:
 	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "init; halt"
 .PHONY: openocd
 
+reset:
+	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "init; reset; exit"
+.PHONY: reset
+
+erase_intflash_1:
+	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "init; halt; flash erase_address 0x08000000 131072; resume; exit"
+.PHONY: erase_intflash1
+
+erase_intflash_2:
+	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "init; halt; flash erase_address 0x08100000 131072; resume; exit"
+.PHONY: erase_intflash2
+
+start_bank_2:
+	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg \
+		-c 'init; reset halt' \
+		-c 'set MSP 0x[string range [mdw 0x08100000] 12 19]' \
+		-c 'set PC 0x[string range [mdw 0x08100004] 12 19]' \
+		-c 'echo "Setting MSP -> $$MSP"' \
+		-c 'echo "Setting PC -> $$PC"' \
+		-c 'reg msp $$MSP' \
+		-c 'reg pc $$PC' \
+		-c 'resume;exit'
+.PHONY: start_bank_2
+
 # Programs the internal flash using a new OpenOCD instance
 flash_intflash: $(BUILD_DIR)/$(TARGET)_intflash.bin
 	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "program $< $(INTFLASH_ADDRESS) verify reset exit"

--- a/README.md
+++ b/README.md
@@ -201,8 +201,6 @@ make clean
 make -j8 EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2
 ```
 
-To actually perform the flash, we will need the [SPI flash external loaders for STM32CubeProgrammer and STM32CubeIDESPI flash external loaders for STM32CubeProgrammer and STM32CubeIDE].
-
 To flash the produced binaries to your device, you have two options:
 1. Using a windows computer with [these SPI flash external loaders](https://www.schuerewegen.tk/download/STM32CubeProgrammer%20External%20Loaders%20%282021-05-02%29.zip):
 
@@ -211,7 +209,7 @@ STM32_Programmer_CLI.exe -c port=SWD -w gw_retro_go_intflash.bin 0x08100000
 STM32_Programmer_CLI.exe -c port=SWD reset=HWrst -w gw_retro_go_extflash.bin 0x90100000 -el "PATH_TO_THE_STLDR_FILE\MX25U51245G_GAME-AND-WATCH.stldr" -rst
 ```
 
-2. Use a [patched version of openocd](https://github.com/kbeckmann/ubuntu-openocd-git-builder) that allows access to the undocumented flash regions of the microcontroller:
+2. Use a [patched version of openocd](https://github.com/kbeckmann/ubuntu-openocd-git-builder) that allows access to the undocumented flash regions of the microcontroller. For mac users, you can use [this homebrew formula](https://github.com/northskysl/homebrew-core/blob/master/Formula/open-ocd.rb):
 
 ```
 make -j8 EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 flash

--- a/README.md
+++ b/README.md
@@ -201,13 +201,20 @@ make clean
 make -j8 EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2
 ```
 
-To actually perform the flash, we will need the [SPI flash external loaders for STM32CubeProgrammer and STM32CubeIDESPI flash external loaders for STM32CubeProgrammer and STM32CubeIDE](https://www.schuerewegen.tk/download/STM32CubeProgrammer%20External%20Loaders%20(2021-05-02%29.zip)).
+To actually perform the flash, we will need the [SPI flash external loaders for STM32CubeProgrammer and STM32CubeIDESPI flash external loaders for STM32CubeProgrammer and STM32CubeIDE].
 
-Using a windows computer, we can now flash the intflash and extflash portions of retro-go using the following commands:
+To flash the produced binaries to your device, you have two options:
+1. Using a windows computer with [these SPI flash external loaders](https://www.schuerewegen.tk/download/STM32CubeProgrammer%20External%20Loaders%20%282021-05-02%29.zip):
 
 ```
 STM32_Programmer_CLI.exe -c port=SWD -w gw_retro_go_intflash.bin 0x08100000
-STM32_Programmer_CLI.exe -c port=SWD reset=HWrst -w gw_retro_go_extflash.bin 0x90100000 -el "PATH_TO_THIS_FILE\MX25U51245G_GAME-AND-WATCH.stldr" -rst
+STM32_Programmer_CLI.exe -c port=SWD reset=HWrst -w gw_retro_go_extflash.bin 0x90100000 -el "PATH_TO_THE_STLDR_FILE\MX25U51245G_GAME-AND-WATCH.stldr" -rst
+```
+
+2. Use a [patched version of openocd](https://github.com/kbeckmann/ubuntu-openocd-git-builder) that allows access to the undocumented flash regions of the microcontroller:
+
+```
+make -j8 EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 flash
 ```
 
 ## Contact, discussion

--- a/scripts/flash_multi.sh
+++ b/scripts/flash_multi.sh
@@ -36,7 +36,7 @@ fi
 # stat on macOS has different flags
 if [[ "$(uname -s)" == "Darwin" ]]; then
     FILESIZE=$(stat -f%z "${IMAGE}")
-else 
+else
     FILESIZE=$(stat -c%s "${IMAGE}")
 fi
 
@@ -105,7 +105,7 @@ while [[ $SIZE -gt 0 ]]; do
         echo ""
         echo ""
         exit 1
-    else 
+    else
         echo ""
         echo ""
         echo_green "Programming of chunk $((i + 1)) / ${CHUNKS} succeeded."

--- a/scripts/interface_jlink.cfg
+++ b/scripts/interface_jlink.cfg
@@ -1,3 +1,4 @@
 source [find interface/jlink.cfg]
 transport select swd
+set DUAL_BANK 1
 source [find target/stm32h7x.cfg]

--- a/scripts/interface_rpi.cfg
+++ b/scripts/interface_rpi.cfg
@@ -2,5 +2,6 @@ source [find interface/sysfsgpio-raspberrypi.cfg]
 sysfsgpio_swd_nums 25 24
 sysfsgpio_srst_num 23
 transport select swd
+set DUAL_BANK 1
 source [find target/stm32h7x.cfg]
 reset_config none

--- a/scripts/interface_stlink.cfg
+++ b/scripts/interface_stlink.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink.cfg]
 adapter speed 500
 transport select hla_swd
-#set DUAL_BANK 1
+set DUAL_BANK 1
 source [find target/stm32h7x.cfg]
 
 reset_config none

--- a/scripts/interface_stlink.cfg
+++ b/scripts/interface_stlink.cfg
@@ -1,6 +1,7 @@
 source [find interface/stlink.cfg]
 adapter speed 500
 transport select hla_swd
+#set DUAL_BANK 1
 source [find target/stm32h7x.cfg]
 
 reset_config none


### PR DESCRIPTION
This fully allows retro-go to be built and flashed to bank2 working with tim's custom firmware. Doesn't impact default bank1 operation.

I added a bunch of makefile targets to aid in development, but some can be deleted if deemed unnecessary clutter.