### PR TITLE
Increase number of brightness levels to 10

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -143,7 +143,7 @@ __attribute__((optimize("-O0"))) void BSOD(BSOD_t fault, void *pc, void *lr)
 
   lcd_sync();
   lcd_reset_active_buffer();
-  odroid_display_set_backlight(ODROID_BACKLIGHT_LEVEL3);
+  odroid_display_set_backlight(ODROID_BACKLIGHT_LEVEL6);
 
   odroid_overlay_draw_text(0, 0, GW_LCD_WIDTH, msg, C_RED, C_BLUE);
 

--- a/Core/Src/porting/odroid_display.c
+++ b/Core/Src/porting/odroid_display.c
@@ -4,7 +4,7 @@
 #include "odroid_display.h"
 #include "gw_lcd.h"
 
-static const uint8_t backlightLevels[] = {128, 144, 160, 192, 255};
+static const uint8_t backlightLevels[] = {128, 130, 133, 139, 149, 162, 178, 198, 222, 255};
 static odroid_display_backlight_t backlightLevel = ODROID_BACKLIGHT_LEVEL3;
 static odroid_display_rotation_t rotationMode = ODROID_DISPLAY_ROTATION_OFF;
 static odroid_display_scaling_t scalingMode = ODROID_DISPLAY_SCALING_FILL;

--- a/Core/Src/porting/odroid_settings.c
+++ b/Core/Src/porting/odroid_settings.c
@@ -48,7 +48,7 @@ static const persistent_config_t persistent_config_default = {
     .magic = CONFIG_MAGIC,
     .version = 1,
 
-    .backlight = ODROID_BACKLIGHT_LEVEL3,
+    .backlight = ODROID_BACKLIGHT_LEVEL6,
     .start_action = ODROID_START_ACTION_RESUME,
     .volume = ODROID_AUDIO_VOLUME_MAX / 2, // Too high volume can cause brown out if the battery isn't connected.
     .font_size = 8,


### PR DESCRIPTION
Relies on:
https://github.com/kbeckmann/retro-go-stm32/pull/14

Basically just gives more granular control on brightness, and it makes the number of brightness levels match the number of audio levels, which has some GUI niceties. I did my best at trying to maintain perceptually constant increments between brightness levels.