### PR TITLE
flashapp: 64-bit progress calculation

### DIFF
--- a/Core/Src/flashapp.c
+++ b/Core/Src/flashapp.c
@@ -149,8 +149,8 @@ static void draw_progress(flashapp_t *flashapp)
     draw_text_line_centered(LIST_Y_OFFSET + 2 * LIST_LINE_HEIGHT, flashapp->tab.name, C_GW_YELLOW, C_BLACK);
 
     if (flashapp->progress_max != 0) {
-        int32_t progress_percent = ((100 * flashapp->progress_value) / flashapp->progress_max);
-        int32_t progress_width = ((PROGRESS_WIDTH * flashapp->progress_value) / flashapp->progress_max);
+        int32_t progress_percent = (100 * flashapp->progress_value) / flashapp->progress_max;
+        int32_t progress_width = (PROGRESS_WIDTH * (uint64_t)flashapp->progress_value) / flashapp->progress_max;
 
         sprintf(progress_str, "%ld%%", progress_percent);
 


### PR DESCRIPTION
This avoids an overflow with big progress values.
Previously, the Flash erase status bar was jumping back to start after every 16 MiB erased.

Please consider merging this small fix to the erase status bar for large Flash.