### PR TITLE
Add naive zelda START and SELECT button support. 

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -46,7 +46,7 @@ typedef enum {
   BSOD_USAGEFAULT,
   BSOD_WATCHDOG,
   BSOD_OTHER,
-  
+
   BSOD_COUNT,
 } BSOD_t;
 
@@ -141,6 +141,13 @@ void wdog_refresh(void);
 #define BTN_Up_GPIO_Port GPIOD
 #define BTN_B_Pin GPIO_PIN_5
 #define BTN_B_GPIO_Port GPIOD
+
+// Zelda only buttons; they are not connected on mario.
+#define BTN_START_Pin GPIO_PIN_11
+#define BTN_START_GPIO_Port GPIOC
+#define BTN_SELECT_Pin GPIO_PIN_12
+#define BTN_SELECT_GPIO_Port GPIOC
+
 /* USER CODE BEGIN Private defines */
 
 #define BOOT_MAGIC_STANDBY  0xfedebeda

--- a/Core/Src/gw_buttons.c
+++ b/Core/Src/gw_buttons.c
@@ -17,6 +17,9 @@ uint32_t buttons_get() {
     bool pause = HAL_GPIO_ReadPin(BTN_PAUSE_GPIO_Port, BTN_PAUSE_Pin) == GPIO_PIN_RESET;
     bool power = HAL_GPIO_ReadPin(BTN_PWR_GPIO_Port, BTN_PWR_Pin) == GPIO_PIN_RESET;
 
+    game |= HAL_GPIO_ReadPin(BTN_START_GPIO_Port, BTN_START_Pin) == GPIO_PIN_RESET;
+    time |= HAL_GPIO_ReadPin(BTN_SELECT_GPIO_Port, BTN_SELECT_Pin) == GPIO_PIN_RESET;
+
     return (
         left | (up << 1) | (right << 2) | (down << 3) | (a << 4) | (b << 5) |
         (time << 6) | (game << 7) | (pause << 8) | (power << 9)

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1196,6 +1196,12 @@ static void MX_GPIO_Init(void)
   GPIO_InitStruct.Pull = GPIO_PULLUP;
   HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
+  /*Configure GPIO pins : BTN_START_Pin BTN_SELECT_Pin */
+  GPIO_InitStruct.Pin = BTN_START_Pin|BTN_SELECT_Pin;
+  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
   /*Configure GPIO pin : BTN_PWR_Pin */
   GPIO_InitStruct.Pin = BTN_PWR_Pin;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;


### PR DESCRIPTION
Currently they just perform the same actions as GAME and TIME, respectively.

These inputs are not connected on the mario unit, so its fine to be reading from them (I verified on actual hardware) regardless of the device.