### PR TITLE
Move dynamic menu item allocation onto stack.

### DIFF
--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -28,6 +28,7 @@ int odroid_overlay_game_menu()
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include <assert.h>
 
 #include "gw_buttons.h"
 #include "gw_lcd.h"
@@ -231,7 +232,14 @@ void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *opti
 
     int options_count = get_dialog_items_count(options);
 
+#ifdef USE_DYNAMIC_MENU_ALLOC
+    // Issues with current code
     char *rows = rg_alloc(options_count * 256, MEM_ANY);
+#else
+    // Use stackspace instead.
+    char rows[16 * 256];
+    assert(options_count < (sizeof(rows) / 256));
+#endif
 
     for (int i = 0; i < options_count; i++)
     {
@@ -290,7 +298,9 @@ void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *opti
     odroid_overlay_draw_rect(box_x, box_y, box_width, box_height, box_padding, box_color);
     odroid_overlay_draw_rect(box_x - 1, box_y - 1, box_width + 2, box_height + 2, 1, box_border_color);
 
+#ifdef USE_DYNAMIC_MENU_ALLOC
     rg_free(rows);
+#endif
 }
 
 int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, int selected)


### PR DESCRIPTION
Fixes an issue with ingame retro-go menu causing an out of memory BSOD.

#2  0x08101948 in abort () at Core/Src/main.c:204
#3  0x08112aa8 in __assert_func ()
...
#7  0x081135b0 in _malloc_r ()
#8  0x08109b92 in rg_alloc (size=size@entry=1536, caps=caps@entry=0) at Core/Src/porting/gw_alloc.c:36
#9  0x08106a74 in odroid_overlay_draw_dialog (header=0x811641c "Retro-Go", options=0x2001f98c, sel=0)
    at Core/Src/porting/odroid_overlay.c:234
#10 0x08106d08 in odroid_overlay_dialog (header=header@entry=0x811641c "Retro-Go", options=options@entry=0x2001f98c,
    selected=selected@entry=0) at Core/Src/porting/odroid_overlay.c:308
#11 0x08107370 in odroid_overlay_game_menu (extra_options=extra_options@entry=0x2001fa98) at Core/Src/porting/odroid_overlay.c:668
#12 0x08105bf6 in common_emu_input_loop (joystick=joystick@entry=0x2001fa78, game_options=game_options@entry=0x2001fa98)
    at Core/Src/porting/common.c:256
#13 0x2405c8f4 in osd_getinput () at Core/Src/porting/nes/main_nes.c:434
#14 0x2406b90e in nes_emulate () at retro-go-stm32/nofrendo-go/components/nofrendo/nes/nes.c:96
#15 0x2405cd98 in nofrendo_start (filename=0x811992c "NFL Football (U) ", region=1, sample_rate=sample_rate@entry=48000,
    stereo=stereo@entry=false) at Core/Src/porting/nes/nofrendo_stm32.c:106
#16 0x2405cc8e in app_main_nes (load_state=<optimized out>, start_paused=<optimized out>) at Core/Src/porting/nes/main_nes.c:568
#17 0x0810abdc in emulator_start (file=file@entry=0x811e724 <nes_roms+14000>, load_state=load_state@entry=true,
    start_paused=start_paused@entry=false) at Core/Src/retro-go/rg_emulators.c:401
#18 0x0810ac94 in emulator_show_file_menu (file=0x811e724 <nes_roms+14000>) at Core/Src/retro-go/rg_emulators.c:359
#19 0x0810acfe in event_handler (event=<optimized out>, tab=0x2000cec4) at Core/Src/retro-go/rg_emulators.c:76
#20 0x0810a348 in retro_loop () at Core/Src/retro-go/rg_main.c:408
#21 0x0810a42e in app_main () at Core/Src/retro-go/rg_main.c:458
#22 0x08102494 in main () at Core/Src/main.c:499