### PR TITLE
Cygwin obj dump

### DIFF
--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -28,6 +28,7 @@ int odroid_overlay_game_menu()
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include <assert.h>
 
 #include "gw_buttons.h"
 #include "gw_lcd.h"
@@ -231,7 +232,14 @@ void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *opti
 
     int options_count = get_dialog_items_count(options);
 
+#ifdef USE_DYNAMIC_MENU_ALLOC
+    // Issues with current code
     char *rows = rg_alloc(options_count * 256, MEM_ANY);
+#else
+    // Use stackspace instead.
+    char rows[16 * 256];
+    assert(options_count < (sizeof(rows) / 256));
+#endif
 
     for (int i = 0; i < options_count; i++)
     {
@@ -290,7 +298,9 @@ void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *opti
     odroid_overlay_draw_rect(box_x, box_y, box_width, box_height, box_padding, box_color);
     odroid_overlay_draw_rect(box_x - 1, box_y - 1, box_width + 2, box_height + 2, 1, box_border_color);
 
+#ifdef USE_DYNAMIC_MENU_ALLOC
     rg_free(rows);
+#endif
 }
 
 int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, int selected)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -44,14 +44,26 @@ fi
 
 function get_symbol {
     name=$1
-    objdump_cmd="${OBJDUMP} -t ${ELF}"
+    uname_out="$(uname -s)"
+    if test "${uname_out#CYGWIN}" != "$uname_out"; then
+        elf_path=$(cygpath -w ${ELF})
+    else
+        elf_path=${ELF}
+    fi
+    objdump_cmd="${OBJDUMP} -t $elf_path"
     size=$(${objdump_cmd} | grep " $name$" | cut -d " " -f1 | tr 'a-f' 'A-F' | head -n 1)
     printf "$((16#${size}))\n"
 }
 
 function get_number_of_saves {
     prefix=$1
-    objdump_cmd="${OBJDUMP} -t ${ELF}"
+    uname_out="$(uname -s)"
+    if test "${uname_out#CYGWIN}" != "$uname_out"; then
+        elf_path=$(cygpath -w ${ELF})
+    else
+        elf_path=${ELF}
+    fi
+    objdump_cmd="${OBJDUMP} -t ${elf_path}"
     echo $(${objdump_cmd} | grep " $prefix" | wc -l)
 }
 


### PR DESCRIPTION
Fix issue with unix paths vs windows paths. objdump expects a windows path but is being given a unix path.