### PR TITLE
Fix for issue [Clear framebuffer after macro OSD disappears #164]

### DIFF
--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -542,7 +542,7 @@ static void draw_darken_rounded_rectangle(pixel_t *fb, uint16_t x1, uint16_t y1,
 }
 
 static inline void clear_pixel(pixel_t *p){
-    *p = 0
+    *p = 0;
 }
 
 __attribute__((optimize("unroll-loops")))

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -541,6 +541,59 @@ static void draw_darken_rounded_rectangle(pixel_t *fb, uint16_t x1, uint16_t y1,
         darken_pixel(&fb[ i + GW_LCD_WIDTH * (y2 - j - 1)]);
 }
 
+static inline void clear_pixel(pixel_t *p){
+    *p = 0
+}
+
+__attribute__((optimize("unroll-loops")))
+static void draw_clear_rectangle(pixel_t *fb, uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2){
+    for(uint16_t i=y1; i < y2; i++){
+        for(uint16_t j=x1; j < x2; j++){
+            clear_pixel(&fb[j + GW_LCD_WIDTH * i]);
+        }
+    }
+}
+
+__attribute__((optimize("unroll-loops")))
+static void draw_clear_rounded_rectangle(pixel_t *fb, uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2){
+    // *1 is inclusive, *2 is exclusive
+    uint16_t h = y2 - y1;
+    uint16_t w = x2 - x1;
+    if (w < 16 || h < 16) {
+        // Draw not rounded rectangle
+        draw_clear_rectangle(fb, x1, y1, x2, y2);
+        return;
+    }
+
+    // Draw upper left round
+    for(uint8_t i=0; i < 8; i++) for(uint8_t j=0; j < 8; j++)
+        if(ROUND[i] & (1 << (7 - j))) clear_pixel(&fb[x1 + j + GW_LCD_WIDTH * (y1 + i)]);
+
+    // Draw upper right round
+    for(uint8_t i=0; i < 8; i++) for(uint8_t j=0; j < 8; j++)
+        if(ROUND[i] & (1 << (7 - j))) clear_pixel(&fb[x2 - j - 1 + GW_LCD_WIDTH * (y1 + i)]);
+
+    // Draw lower left round
+    for(uint8_t i=0; i < 8; i++) for(uint8_t j=0; j < 8; j++)
+        if(ROUND[i] & (1 << (7 - j))) clear_pixel(&fb[x1 + j + GW_LCD_WIDTH * (y2 - i - 1)]);
+
+    // Draw lower right round
+    for(uint8_t i=0; i < 8; i++) for(uint8_t j=0; j < 8; j++)
+        if(ROUND[i] & (1 <<  (7 - j))) clear_pixel(&fb[x2 - j - 1 + GW_LCD_WIDTH * (y2 - i - 1)]);
+
+    // Draw upper rectangle
+    for(uint16_t i=x1+8; i < x2 - 8; i++) for(uint8_t j=0; j < 8; j++)
+        clear_pixel(&fb[ i + GW_LCD_WIDTH * (y1 + j)]);
+
+    // Draw central rectangle
+    for(uint16_t i=x1; i < x2; i++) for(uint16_t j=y1+8; j < y2-8; j++)
+        clear_pixel(&fb[i+GW_LCD_WIDTH * j]);
+
+    // Draw lower rectangle
+    for(uint16_t i=x1+8; i < x2 - 8; i++) for(uint8_t j=0; j < 8; j++)
+        clear_pixel(&fb[ i + GW_LCD_WIDTH * (y2 - j - 1)]);
+}
+
 #define INGAME_OVERLAY_X 265
 #define INGAME_OVERLAY_Y 10
 #define INGAME_OVERLAY_BARS_H 128
@@ -679,7 +732,29 @@ void common_ingame_overlay(void) {
     }
 }
 
+void common_ingame_overlay_clear(void) {
+    pixel_t *fb;
+    
+    fb = lcd_get_active_buffer();
+    draw_clear_rounded_rectangle(fb,
+                    INGAME_OVERLAY_X,
+                    INGAME_OVERLAY_Y,
+                    INGAME_OVERLAY_X + INGAME_OVERLAY_BARS_W,
+                    INGAME_OVERLAY_Y + INGAME_OVERLAY_BARS_H);
+
+    fb = lcd_get_inactive_buffer();
+    draw_clear_rounded_rectangle(fb,
+                    INGAME_OVERLAY_X,
+                    INGAME_OVERLAY_Y,
+                    INGAME_OVERLAY_X + INGAME_OVERLAY_BARS_W,
+                    INGAME_OVERLAY_Y + INGAME_OVERLAY_BARS_H);
+}
+
 static void set_ingame_overlay(ingame_overlay_t type){
+    if((type == INGAME_OVERLAY_NONE) && (common_emu_state.overlay != INGAME_OVERLAY_NONE)) {    // when transitioning from any overlay to no overlay
+        common_ingame_overlay_clear();  // clear the overlay area. This will ensure no partial overlay leftovers when emulation area does not fully cover the overlay area
+    }
+
     common_emu_state.overlay = type;
     common_emu_state.last_overlay_time = get_elapsed_time();
 }


### PR DESCRIPTION
This is a fix proposition for issue #164. Basically, in any transition from any overlay to no overlay, we draw a black rounded rectangle of the same size and at the same position as the overlays are drawn. NOTE: we do so in both the active and the inactive frame buffers.